### PR TITLE
Changed timestamp files to use Carbon instead of gmdate method

### DIFF
--- a/resources/views/formfields/timestamp.blade.php
+++ b/resources/views/formfields/timestamp.blade.php
@@ -1,2 +1,2 @@
 <input @if($row->required == 1) required @endif type="datetime" class="form-control datepicker"  data-name="{{ $row->display_name }}"  name="{{ $row->field }}"
-       value="@if(isset($dataTypeContent->{$row->field})){{ gmdate('m/d/Y g:i A', strtotime(old($row->field, $dataTypeContent->{$row->field})))  }}@else{{old($row->field)}}@endif">
+       value="@if(isset($dataTypeContent->{$row->field})){{ \Carbon\Carbon::parse(old($row->field, $dataTypeContent->{$row->field}))->format('m/d/Y g:i A') }}@else{{old($row->field)}}@endif">

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -406,7 +406,7 @@ abstract class Controller extends BaseController
                     if (empty($request->input($row->field))) {
                         $content = null;
                     } else {
-                        $content = gmdate('Y-m-d H:i:s', strtotime($request->input($row->field)));
+                        $content = \Carbon\Carbon::parse($content);
                     }
                 }
                 break;


### PR DESCRIPTION
Possible fix for the Issue #2369 
Replaced usage of gmdate method with Carbon that will follow Laravel's timezone settings.