### PR TITLE
Add resizable traits

### DIFF
--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -6,11 +6,13 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\Resizable;
 use TCG\Voyager\Traits\Translatable;
 
 class Post extends Model
 {
     use Translatable;
+    use Resizable;
 
     protected $translatable = ['title', 'seo_title', 'excerpt', 'body', 'slug', 'meta_description', 'meta_keywords'];
 
@@ -51,20 +53,5 @@ class Post extends Model
     public function category()
     {
         return $this->hasOne(Voyager::modelClass('Category'), 'id', 'category_id');
-    }
-
-    /**
-     *   Method for returning specific thumbnail for post.
-     */
-    public function thumbnail($type)
-    {
-        // We take image from posts field
-        $image = $this->attributes['image'];
-        // We need to get extension type ( .jpeg , .png ...)
-        $ext = pathinfo($image, PATHINFO_EXTENSION);
-        // We remove extension from file name so we can append thumbnail type
-        $name = rtrim($image, '.'.$ext);
-        // We merge original name + type + extension
-        return $name.'-'.$type.'.'.$ext;
     }
 }

--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -5,16 +5,28 @@ namespace TCG\Voyager\Traits;
 trait Resizable
 {
     /**
-     *   Method for returning specific thumbnail for model.
+     * Method for returning specific thumbnail for model.
+     *
+     * @param string $type
+     * @param string $attribute
+     * @return string
      */
-    public function thumbnail($type)
+    public function thumbnail($type, $attribute = 'image')
     {
+        // Return empty string if the field not found
+        if(!isset($this->attributes[$attribute])) {
+            return '';
+        }
+
         // We take image from posts field
-        $image = $this->attributes['image'];
+        $image = $this->attributes[$attribute];
+
         // We need to get extension type ( .jpeg , .png ...)
         $ext = pathinfo($image, PATHINFO_EXTENSION);
+
         // We remove extension from file name so we can append thumbnail type
         $name = rtrim($image, '.'.$ext);
+
         // We merge original name + type + extension
         return $name.'-'.$type.'.'.$ext;
     }

--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TCG\Voyager\Traits;
+
+trait Resizable
+{
+    /**
+     *   Method for returning specific thumbnail for model.
+     */
+    public function thumbnail($type)
+    {
+        // We take image from posts field
+        $image = $this->attributes['image'];
+        // We need to get extension type ( .jpeg , .png ...)
+        $ext = pathinfo($image, PATHINFO_EXTENSION);
+        // We remove extension from file name so we can append thumbnail type
+        $name = rtrim($image, '.'.$ext);
+        // We merge original name + type + extension
+        return $name.'-'.$type.'.'.$ext;
+    }
+}

--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -9,12 +9,13 @@ trait Resizable
      *
      * @param string $type
      * @param string $attribute
+     *
      * @return string
      */
     public function thumbnail($type, $attribute = 'image')
     {
         // Return empty string if the field not found
-        if(!isset($this->attributes[$attribute])) {
+        if (!isset($this->attributes[$attribute])) {
             return '';
         }
 


### PR DESCRIPTION
This traits will allow us to use thumbnail helper to generate image url when using Image additional fields. See: https://voyager.readme.io/docs/additional-field-options#section-image

Example of use:
```
use TCG\Voyager\Traits\Resizable;

class Post extends Model
{
    use Resizable;
}
```

Use it on view (usually on your site frontend):
```
@foreach($posts as $post)
    {{$post->thumbnail('small')}}
@endforeach
```

Or you can specify the optional image field name (attribute), default to `image`
```
@foreach($posts as $post)
    {{$post->thumbnail('small', 'photo')}}
@endforeach
```
  
  
  