### PR TITLE
Moved getRelationship() to trait

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -11,7 +11,11 @@
 				@php 
 					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
 					$model = app($options->model);
-					$query = $model::getRelationship($relationshipData->{$options->column});
+					if (method_exists($model, 'getRelationship')) {
+						$query = $model::getRelationship($relationshipData->{$options->column});
+					} else {
+						$query = $model::find($relationshipData->{$options->column});
+					}
             	@endphp
 
             	@if(isset($query))

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -4,11 +4,13 @@ namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\HasRelationships;
 use TCG\Voyager\Traits\Translatable;
 
 class Category extends Model
 {
-    use Translatable;
+    use Translatable,
+        HasRelationships;
 
     protected $translatable = ['slug', 'name'];
 

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -4,11 +4,13 @@ namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use TCG\Voyager\Traits\HasRelationships;
 use TCG\Voyager\Traits\Translatable;
 
 class Page extends Model
 {
-    use Translatable;
+    use Translatable,
+        HasRelationships;
 
     protected $translatable = ['title', 'slug', 'body'];
 

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -3,9 +3,12 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use TCG\Voyager\Traits\HasRelationships;
 
 class Permission extends Model
 {
+    use HasRelationships;
+
     protected $guarded = [];
 
     public function roles()

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -6,13 +6,15 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\HasRelationships;
 use TCG\Voyager\Traits\Resizable;
 use TCG\Voyager\Traits\Translatable;
 
 class Post extends Model
 {
-    use Translatable;
-    use Resizable;
+    use Translatable,
+        Resizable,
+        HasRelationships;
 
     protected $translatable = ['title', 'seo_title', 'excerpt', 'body', 'slug', 'meta_description', 'meta_keywords'];
 

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -4,11 +4,13 @@ namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\HasRelationships;
 
 class Role extends Model
 {
+    use HasRelationships;
+
     protected $guarded = [];
-    protected static $relationships = [];
 
     public function users()
     {
@@ -18,14 +20,5 @@ class Role extends Model
     public function permissions()
     {
         return $this->belongsToMany(Voyager::modelClass('Permission'));
-    }
-
-    public static function getRelationship($id)
-    {
-        if (!isset(self::$relationships[$id])) {
-            self::$relationships[$id] = self::find($id);
-        }
-
-        return self::$relationships[$id];
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -5,11 +5,13 @@ namespace TCG\Voyager\Models;
 use Carbon\Carbon;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use TCG\Voyager\Contracts\User as UserContract;
+use TCG\Voyager\Traits\HasRelationships;
 use TCG\Voyager\Traits\VoyagerUser;
 
 class User extends Authenticatable implements UserContract
 {
-    use VoyagerUser;
+    use VoyagerUser,
+        HasRelationships;
 
     protected $guarded = [];
 

--- a/src/Traits/HasRelationships.php
+++ b/src/Traits/HasRelationships.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace TCG\Voyager\Traits;
+
+
+trait HasRelationships
+{
+    protected static $relationships = [];
+
+    public static function getRelationship($id)
+    {
+        if (!isset(self::$relationships[$id])) {
+            self::$relationships[$id] = self::find($id);
+        }
+
+        return self::$relationships[$id];
+    }
+}


### PR DESCRIPTION
As part of #2339, a method called `getRelationship()` was added as a caching layer, but it was only added to the `Role` model.  A call to it was also added to the `relationship` form field view, which is loaded by any BREAD that has a relationship configured, not just `Role`, so it's breaking (reported in #2431).

This change moves that method into a trait and adds that trait to all models that could reasonably have relationships added through BREAD.  Documentation will need to be added to inform devs that they need to add this trait to their own models.

Fixes #2431 