### PR TITLE
MenuItemPolicy accesses key instead of name

### DIFF
--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -37,7 +37,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         // If permission doesn't exist, we can't check it!
-        if (!Voyager::model('Permission')->where('key', '=', 'browse_'.$slug)->exists()) {
+        if (!Voyager::model('Permission')->whereKey('browse_'.$slug)->exists()) {
             return true;
         }
 

--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -37,7 +37,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         // If permission doesn't exist, we can't check it!
-        if (!Voyager::model('Permission')->where('key','browse_'.$slug)->exists()) {
+        if (!Voyager::model('Permission')->where('key', '=', 'browse_'.$slug)->exists()) {
             return true;
         }
 

--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -37,7 +37,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         // If permission doesn't exist, we can't check it!
-        if (!Voyager::model('Permission')->whereName('browse_'.$slug)->exists()) {
+        if (!Voyager::model('Permission')->where('key','browse_'.$slug)->exists()) {
             return true;
         }
 


### PR DESCRIPTION
MenuItemPolicy accesses now the key column instead of the name column of permissions table. The latter produced an error:

![image](https://user-images.githubusercontent.com/1765602/34612629-e26c9a56-f22a-11e7-83bb-5efcac3b425c.png)
