### PR TITLE
Fix #1469 timestamp can have format option

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -121,7 +121,7 @@
 
                                                 @elseif($row->type == 'select_dropdown' && $data->{$row->field . '_page_slug'})
                                                     <a href="{{ $data->{$row->field . '_page_slug'} }}">{{ $data->{$row->field} }}</a>
-                                                @elseif($row->type == 'date')
+                                                @elseif($row->type == 'date' || $row->type == 'timestamp')
                                                 {{ $options && property_exists($options, 'format') ? \Carbon\Carbon::parse($data->{$row->field})->formatLocalized($options->format) : $data->{$row->field} }}
                                                 @elseif($row->type == 'checkbox')
                                                     @if($options && property_exists($options, 'on') && property_exists($options, 'off'))

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -78,7 +78,7 @@
                                      {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
                                     @endforeach
                                 @endif
-                            @elseif($row->type == 'date')
+                            @elseif($row->type == 'date' || $row->type == 'timestamp')
                                 {{ $rowDetails && property_exists($rowDetails, 'format') ? \Carbon\Carbon::parse($dataTypeContent->{$row->field})->formatLocalized($rowDetails->format) : $dataTypeContent->{$row->field} }}
                             @elseif($row->type == 'checkbox')
                                 @if($rowDetails && property_exists($rowDetails, 'on') && property_exists($rowDetails, 'off'))


### PR DESCRIPTION
Allow timestamp to use `format` option.

See https://voyager.readme.io/docs/additional-field-options#section-date

Fixes #1469