### PR TITLE
Fixes #2475

### DIFF
--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -37,7 +37,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         // If permission doesn't exist, we can't check it!
-        if (!Voyager::model('Permission')->whereKey('browse_'.$slug)->exists()) {
+        if (!Voyager::model('Permission')->where('key', 'browse_'.$slug)->exists()) {
             return true;
         }
 


### PR DESCRIPTION
`whereKey` is an actual method and doesn't work as shorthand for `where(attr, val)`

Fixes #2475 