### PR TITLE
Fix user-role relationship

### DIFF
--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -3,8 +3,9 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use TCG\Voyager\Traits\HasRelationships;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\HasRelationships;
+
 
 class Permission extends Model
 {

--- a/src/Models/Permission.php
+++ b/src/Models/Permission.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Traits\HasRelationships;
+use TCG\Voyager\Facades\Voyager;
 
 class Permission extends Model
 {
@@ -13,7 +14,7 @@ class Permission extends Model
 
     public function roles()
     {
-        return $this->hasMany(Role::class);
+        return $this->hasMany(Voyager::modelClass('Role'));
     }
 
     public static function generateFor($table_name)

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -14,7 +14,7 @@ class Role extends Model
 
     public function users()
     {
-        return $this->belongsToMany(Voyager::modelClass('User'), 'user_roles');
+        return $this->belongsTo(Voyager::modelClass('User'), 'id', 'role_id');
     }
 
     public function permissions()

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -14,7 +14,7 @@ class Role extends Model
 
     public function users()
     {
-        return $this->belongsTo(Voyager::modelClass('User'), 'id', 'role_id');
+        return $this->hasMany(Voyager::modelClass('User'));
     }
 
     public function permissions()

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -13,7 +13,7 @@ trait VoyagerUser
 {
     public function role()
     {
-        return $this->belongsTo(Voyager::modelClass('Role'));
+        return $this->hasOne(Voyager::modelClass('Role'), 'id', 'role_id');
     }
 
     /**

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -13,7 +13,7 @@ trait VoyagerUser
 {
     public function role()
     {
-        return $this->hasOne(Voyager::modelClass('Role'), 'id', 'role_id');
+        return $this->belongsTo(Voyager::modelClass('Role'));
     }
 
     /**


### PR DESCRIPTION
The relationship User Role was broken, it was using a pivot table `user_roles` that did not exist.
I updated the code to not use the pivot table.

I took the chance to add Voyager::modelClass in the relationship inside `./src/Model/Permission.php`