### PR TITLE
Move scripts section after additional_js

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -130,11 +130,12 @@ if ((substr(Auth::user()->avatar, 0, 7) == 'http://') || (substr(Auth::user()->a
 
     @endif
 </script>
-@yield('javascript')
 
 @if(!empty(config('voyager.additional_js')))<!-- Additional Javascript -->
     @foreach(config('voyager.additional_js') as $js)<script type="text/javascript" src="{{ asset($js) }}"></script>@endforeach
 @endif
+
+@yield('javascript')
 
 </body>
 </html>


### PR DESCRIPTION
Scripts specific to a page that go into the scripts section in the master blade file should come after the additional javascript files specified in the config file. Many page related scripts may require intitial files to be loaded in in order to be executed.