### PR TITLE
SQL Integrity violation in relationship.blade.php

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -143,7 +143,7 @@
 				<select class="form-control select2" name="{{ $relationshipField }}[]" multiple>
 					
 			            @php 
-					$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->key)->all() : array();
+					$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->table.'.'.$options->key)->all() : array();
 			                $relationshipOptions = app($options->model)->all();
 			            @endphp
 


### PR DESCRIPTION
When I create a belongsToMany relationship and when I try to edit a model value an error occured: 

> SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in field list is ambiguous (SQL: select `id` from `company_types` inner join `brands_company_types` on `company_types`.`id` = `brands_company_types`.`company_type_id` where `brands_company_types`.`brand_id` = 2) (View: /var/www/category-task.lanservicegroup.it/vendor/tcg/voyager/resources/views/formfields/relationship.blade.php) (View: /var/www/category-task.lanservicegroup.it/vendor/tcg/voyager/resources/views/formfields/relationship.blade.php)

Adding the model table error gone.