### PR TITLE
Fixed saving belongsto relation field issue

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -26,7 +26,7 @@
 
 			@else
 			
-				<select class="form-control select2" name="{{ $options->column }}">
+				<select class="form-control select2" name="{{ $relationshipField }}">
 					@php 
 						$model = app($options->model);
 	            		$query = $model::all();


### PR DESCRIPTION
I was having an issue where I couldn't save a relation. It would just take id=1 on every save. 
Apparently a select field was using wrong value as name. Further below in the file it is used correctly.

Here is a relation i was using: 
![](https://image.prntscr.com/image/JVRJfqooSdeoYBIhrf4BAA.png)

The the name attribute of select was set to user_id which is incorrect.
![](https://image.prntscr.com/image/jNXS29ugQbij-Y_c6I_hcA.png)