### PR TITLE
Use example.com instead of admin.com for dummy user

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Start up a local development server with `php artisan serve` And, visit [http://
 
 If you did go ahead with the dummy data, a user should have been created for you with the following login credentials:
 
->**email:** `admin@admin.com`   
+>**email:** `admin@example.com`   
 >**password:** `password`
 
 NOTE: Please note that a dummy user is **only** created if there are no current users in your database.

--- a/publishable/database/seeds/UsersTableSeeder.php
+++ b/publishable/database/seeds/UsersTableSeeder.php
@@ -18,7 +18,7 @@ class UsersTableSeeder extends Seeder
 
             User::create([
                 'name'           => 'Admin',
-                'email'          => 'admin@admin.com',
+                'email'          => 'admin@example.com',
                 'password'       => bcrypt('password'),
                 'remember_token' => str_random(60),
                 'role_id'        => $role->id,


### PR DESCRIPTION
We should use the `example.com` domain because this is a reserved domain name for such purposes (https://www.iana.org/domains/reserved). `admin.com` is not reserved.