### PR TITLE
Fix to change illuminate/support dependency version to allow installation with laravel 5.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tcg/voyager",
+    "name": "bbguitar/voyager",
     "description": "A Laravel Admin Package for The Control Group to make your life easier and steer your project in the right direction",
     "keywords": ["laravel", "admin", "panel"],
     "license": "MIT",
@@ -8,14 +8,12 @@
         "issues": "https://github.com/the-control-group/voyager/issues",
         "source": "https://github.com/the-control-group/voyager"
     },
-    "authors": [
-        {
-            "name": "Tony Lea",
-            "email": "tony.lea@thecontrolgroup.com"
-        }
-    ],
+    "authors": [{
+        "name": "Tony Lea",
+        "email": "tony.lea@thecontrolgroup.com"
+    }],
     "require": {
-        "illuminate/support": "~5.4.0|~5.5.0",
+        "illuminate/support": "~5.4.0|~5.6.1",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",
         "larapack/doctrine-support": "~0.1.4",
@@ -42,7 +40,7 @@
     "autoload-dev": {
         "psr-4": {
             "TCG\\Voyager\\Tests\\": "tests/"
-      }
+        }
     },
     "minimum-stability": "stable",
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "bbguitar/voyager",
+    "name": "tcg/voyager",
     "description": "A Laravel Admin Package for The Control Group to make your life easier and steer your project in the right direction",
     "keywords": ["laravel", "admin", "panel"],
     "license": "MIT",


### PR DESCRIPTION
Visually tested with mysql backend but may be issues with sqlite.
Putting this here for others to run alternative tests.