### PR TITLE
Re #2287: Cover Image Upload Field Accepts Non-Image Filetypes

### DIFF
--- a/resources/views/formfields/image.blade.php
+++ b/resources/views/formfields/image.blade.php
@@ -2,4 +2,4 @@
     <img src="@if( !filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $dataTypeContent->{$row->field} ) }}@else{{ $dataTypeContent->{$row->field} }}@endif"
          style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:10px;">
 @endif
-<input @if($row->required == 1 && !isset($dataTypeContent->{$row->field})) required @endif type="file" name="{{ $row->field }}">
+<input @if($row->required == 1 && !isset($dataTypeContent->{$row->field})) required @endif type="file" name="{{ $row->field }}" accept="image/*">

--- a/resources/views/formfields/multiple_images.blade.php
+++ b/resources/views/formfields/multiple_images.blade.php
@@ -11,4 +11,4 @@
     @endif
 @endif
 <div class="clearfix"></div>
-<input @if($row->required == 1) required @endif type="file" name="{{ $row->field }}[]" multiple="multiple">
+<input @if($row->required == 1) required @endif type="file" name="{{ $row->field }}[]" multiple="multiple" accept="image/*">


### PR DESCRIPTION
- Add `accept="image/*"` as recommended by @envision

Closes #2287