### PR TITLE
Remember settings tab

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -229,20 +229,21 @@
         <form action="{{ route('voyager.settings.update') }}" method="POST" enctype="multipart/form-data">
             {{ method_field("PUT") }}
             {{ csrf_field() }}
+            <input type="hidden" name="setting_tab" class="setting_tab" value="{{ $active }}" />
             <div class="panel">
 
                 <div class="page-content settings container-fluid">
                     <ul class="nav nav-tabs">
-                      @foreach($settings as $group => $setting)
-                      <li @if($loop->first) class="active" @endif>
-                          <a data-toggle="tab" href="#{{ str_slug($group) }}">{{ $group }}</a>
-                      </li>
-                      @endforeach
+                        @foreach($settings as $group => $setting)
+                            <li @if($group == $active) class="active" @endif>
+                                <a data-toggle="tab" href="#{{ str_slug($group) }}">{{ $group }}</a>
+                            </li>
+                        @endforeach
                     </ul>
 
                     <div class="tab-content">
                         @foreach($settings as $group => $group_settings)
-                        <div id="{{ str_slug($group) }}" class="tab-pane fade in @if($loop->first) active @endif">
+                        <div id="{{ str_slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
                             @foreach($group_settings as $setting)
                             <div class="panel-heading">
                                 <h3 class="panel-title">
@@ -355,6 +356,7 @@
             <div class="panel-body">
                 <form action="{{ route('voyager.settings.store') }}" method="POST">
                     {{ csrf_field() }}
+                    <input type="hidden" name="setting_tab" class="setting_tab" value="{{ $active }}" />
                     <div class="col-md-3">
                         <label for="display_name">{{ __('voyager::voyager.generic.name') }}</label>
                         <input type="text" class="form-control" name="display_name" placeholder="{{ __('voyager::voyager.settings.help_name') }}" required="required">
@@ -455,6 +457,10 @@
             });
 
             $('.toggleswitch').bootstrapToggle();
+
+            $('[data-toggle="tab"]').click(function() {
+                $(".setting_tab").val($(this).html());
+            });
         });
     </script>
     <script type="text/javascript">

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -36,7 +36,7 @@ class VoyagerSettingsController extends Controller
             }
         }
 
-        $active = (request()->session()->has('setting_tab'))? request()->session()->get('setting_tab') : old('setting_tab', key($settings));
+        $active = (request()->session()->has('setting_tab')) ? request()->session()->get('setting_tab') : old('setting_tab', key($settings));
 
         return Voyager::view('voyager::settings.index', compact('settings', 'groups', 'active'));
     }

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -36,7 +36,9 @@ class VoyagerSettingsController extends Controller
             }
         }
 
-        return Voyager::view('voyager::settings.index', compact('settings', 'groups'));
+        $active = (request()->session()->has('setting_tab'))? request()->session()->get('setting_tab') : old('setting_tab', key($settings));
+
+        return Voyager::view('voyager::settings.index', compact('settings', 'groups', 'active'));
     }
 
     public function store(Request $request)
@@ -66,7 +68,9 @@ class VoyagerSettingsController extends Controller
         $request->merge(['value' => '']);
         $request->merge(['key' => $key]);
 
-        Voyager::model('Setting')->create($request->all());
+        Voyager::model('Setting')->create($request->except('setting_tab'));
+
+        request()->flashOnly('setting_tab');
 
         return back()->with([
             'message'    => __('voyager::voyager.settings.successfully_created'),
@@ -101,6 +105,8 @@ class VoyagerSettingsController extends Controller
             $setting->save();
         }
 
+        request()->flashOnly('setting_tab');
+
         return back()->with([
             'message'    => __('voyager::voyager.settings.successfully_saved'),
             'alert-type' => 'success',
@@ -112,7 +118,11 @@ class VoyagerSettingsController extends Controller
         // Check permission
         $this->authorize('delete', Voyager::model('Setting'));
 
+        $setting = Voyager::model('Setting')->find($id);
+
         Voyager::model('Setting')->destroy($id);
+
+        request()->session()->flash('setting_tab', $setting->group);
 
         return back()->with([
             'message'    => __('voyager::voyager.settings.successfully_deleted'),
@@ -152,6 +162,8 @@ class VoyagerSettingsController extends Controller
             ];
         }
 
+        request()->session()->flash('setting_tab', $setting->group);
+
         return back()->with($data);
     }
 
@@ -172,6 +184,8 @@ class VoyagerSettingsController extends Controller
             $setting->value = '';
             $setting->save();
         }
+
+        request()->session()->flash('setting_tab', $setting->group);
 
         return back()->with([
             'message'    => __('voyager::voyager.settings.successfully_removed', ['name' => $setting->display_name]),
@@ -211,6 +225,8 @@ class VoyagerSettingsController extends Controller
                 'alert-type' => 'success',
             ];
         }
+
+        request()->session()->flash('setting_tab', $setting->group);
 
         return back()->with($data);
     }


### PR DESCRIPTION
When I was working with the settings module, it felt 'awkward' that whenever I performed an action on the page, the current active tab wasn't remembered on the next page load.

This pull request adds that feature to the settings module.