### PR TITLE
Correct tabindex on database/ select elements

### DIFF
--- a/resources/views/tools/database/vue-components/database-column.blade.php
+++ b/resources/views/tools/database/vue-components/database-column.blade.php
@@ -31,7 +31,7 @@
     <td>
         <select :value="index.type" @change="onIndexTypeChange"
                 :disabled="column.type.notSupportIndex"
-                class="form-control" tabindex="-1">
+                class="form-control">
             <option value=""></option>
             <option value="INDEX">{{ __('voyager.database.index') }}</option>
             <option value="UNIQUE">{{ __('voyager.database.unique') }}</option>

--- a/resources/views/tools/database/vue-components/database-types.blade.php
+++ b/resources/views/tools/database/vue-components/database-types.blade.php
@@ -1,7 +1,7 @@
 @section('database-types-template')
 
 <div>
-    <select :value="column.type.name" @change="onTypeChange" class="form-control" tabindex="-1">
+    <select :value="column.type.name" @change="onTypeChange" class="form-control">
         <optgroup v-for="(types, category) in dbTypes" :label="category">
             <option v-for="type in types" :value="type.name" :disabled="type.notSupported">
                 @{{ type.name.toUpperCase() }}


### PR DESCRIPTION
Removed `tabindex="-1"` in two locations

I made this change and was able to still create and edit tables without issue. Being a keyboard junkie I found the ability to tab through the columns very nice :)

Fixes #2744 