### PR TITLE
Allows editing of hasMany relations in BREAD-generated forms

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -76,15 +76,19 @@
 	            		<p>{{ $string_values }}</p>
 	            	@endif
 	            @else
-	            	@if(empty($selected_values))
-		            	<p>No results</p>
-		            @else
-		            	<ul>
-			            	@foreach($selected_values as $selected_value)
-			            		<li>{{ $selected_value }}</li>
-			            	@endforeach
-			            </ul>
-			        @endif
+
+                    @php
+                        $model = app($options->model);
+                        $selected_values = $model::where($options->column, '=', $dataTypeContent->id)->get()->pluck($options->key)->toArray();
+                        $all = $model::all();
+                    @endphp
+
+                    <select autocomplete="off" class="form-control select2" name="{{ $relationshipField }}[]" multiple>
+                        @foreach($all as $relationshipOption)
+                            <option value="{{ $relationshipOption->{$options->key} }}" @if(in_array($relationshipOption->{$options->key}, $selected_values)) selected @endif>{{ $relationshipOption->{$options->label} }}</option>
+                        @endforeach
+                    </select>
+
 	            @endif
 
 			@else

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -43,6 +43,7 @@ abstract class Controller extends BaseController
     public function insertUpdateData($request, $slug, $rows, $data)
     {
         $multi_select = [];
+        $has_many_relations = [];
 
         /*
          * Prepare Translations and Transform data
@@ -56,7 +57,12 @@ abstract class Controller extends BaseController
 
             // if the field for this row is absent from the request, continue
             // checkboxes will be absent when unchecked, thus they are the exception
-            if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
+            // Same exception applies to hasMany relations
+            if (!$request->hasFile($row->field) &&
+                !$request->has($row->field) &&
+                $row->type !== 'checkbox' &&
+                ($row->type !== 'relationship' || $options->type !== 'hasMany')
+            ) {
                 continue;
             }
 
@@ -103,6 +109,16 @@ abstract class Controller extends BaseController
             if ($row->type == 'relationship' && $options->type == 'belongsToMany') {
                 // Only if select_multiple is working with a relationship
                 $multi_select[] = ['model' => $options->model, 'content' => $content, 'table' => $options->pivot_table];
+            } elseif ($row->type == 'relationship' && $options->type == 'hasMany') {
+                $ids = !empty($content) ? $content : [];
+                $has_many_relations[] = [
+                    'modelName' => $options->model,
+                    'foreignKey' => $options->column,
+                    'localKey' => $options->key,
+                    'ids' => $ids,
+                    // assuming that the relation attribute is same as table name
+                    'attribute' => $options->table,
+                ];
             } else {
                 $data->{$row->field} = $content;
             }
@@ -113,6 +129,23 @@ abstract class Controller extends BaseController
         // Save translations
         if (count($translations) > 0) {
             $data->saveTranslations($translations);
+        }
+
+        // Set hasMany relations
+        foreach ($has_many_relations as $has_many) {
+            $model_name = $has_many['modelName'];
+            $foreign_key = $has_many['foreignKey'];
+            $local_id = $data->getKey();
+
+            // Unset previous relations
+            $model_name::where($foreign_key, '=', $local_id)
+                ->update([$foreign_key => null]);
+
+            // Set new relations
+            if (!empty($has_many['ids'])) {
+                $related_collection = $model_name::find($has_many['ids']);
+                $data->{$has_many['attribute']}()->saveMany($related_collection);
+            }
         }
 
         foreach ($multi_select as $sync_data) {


### PR DESCRIPTION
Creating a hasMany relation wouldn't allow the parent object form to edit the relations. For example, you can't add players to a team when only a player can play only in one team. You could only set the team when editing a player.

This adds the multiselect in the BREAD-generated form to choose child relations and controller code to handle the changes.