### PR TITLE
Allows editing of hasMany relations in BREAD-generated forms

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -76,15 +76,19 @@
 	            		<p>{{ $string_values }}</p>
 	            	@endif
 	            @else
-	            	@if(empty($selected_values))
-		            	<p>No results</p>
-		            @else
-		            	<ul>
-			            	@foreach($selected_values as $selected_value)
-			            		<li>{{ $selected_value }}</li>
-			            	@endforeach
-			            </ul>
-			        @endif
+
+                    @php
+                        $model = app($options->model);
+                        $selected_values = $model::where($options->column, '=', $dataTypeContent->id)->get()->pluck($options->key)->toArray();
+                        $all = $model::all();
+                    @endphp
+
+                    <select autocomplete="off" class="form-control select2" name="{{ $relationshipField }}[]" multiple>
+                        @foreach($all as $relationshipOption)
+                            <option value="{{ $relationshipOption->{$options->key} }}" @if(in_array($relationshipOption->{$options->key}, $selected_values)) selected @endif>{{ $relationshipOption->{$options->label} }}</option>
+                        @endforeach
+                    </select>
+
 	            @endif
 
 			@else


### PR DESCRIPTION
Creating a hasMany relation wouldn't allow the parent object form to edit the relations. For example, you can't add players to a team when only a player can play only in one team. You could only set the team when editing a player.

This adds the multiselect in the BREAD-generated form to choose child relations and controller code to handle the changes.