### PR TITLE
Fix Dropdowns not working with asian menu-titles

### DIFF
--- a/resources/views/menu/admin_menu.blade.php
+++ b/resources/views/menu/admin_menu.blade.php
@@ -43,7 +43,7 @@
                 continue;
             }
 
-            $linkAttributes = 'href="#' . str_slug($transItem->title, '-') .'-dropdown-element" data-toggle="collapse" aria-expanded="'. (in_array('active', $listItemClass) ? 'true' : 'false').'"';
+            $linkAttributes = 'href="#' . $transItem->id .'-dropdown-element" data-toggle="collapse" aria-expanded="'. (in_array('active', $listItemClass) ? 'true' : 'false').'"';
             array_push($listItemClass, 'dropdown');
         }
         else
@@ -62,7 +62,7 @@
             <span class="title">{{ $transItem->title }}</span>
         </a>
         @if($hasChildren)
-            <div id="{{ str_slug($transItem->title, '-') }}-dropdown-element" class="panel-collapse collapse {{ (in_array('active', $listItemClass) ? 'in' : '') }}">
+            <div id="{{ $transItem->id }}-dropdown-element" class="panel-collapse collapse {{ (in_array('active', $listItemClass) ? 'in' : '') }}">
                 <div class="panel-body">
                     @include('voyager::menu.admin_menu', ['items' => $item->children, 'options' => $options, 'innerLoop' => true])
                 </div>


### PR DESCRIPTION
Now dropdowns use the ID instead of the slug.
For more details see https://github.com/the-control-group/voyager/issues/2688#issuecomment-366508917

Fixes #2148 
Fixes #2784
Fixes #2688 
Fixes #2787 