### PR TITLE
Multiple images fields show full size images on edit-form

### DIFF
--- a/resources/views/formfields/multiple_images.blade.php
+++ b/resources/views/formfields/multiple_images.blade.php
@@ -3,8 +3,8 @@
     <?php $images = json_decode($dataTypeContent->{$row->field}); ?>
     @if($images != null)
         @foreach($images as $image)
-            <div class="img_settings_container" data-field-name="{{ $row->field }}">
-                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->id }}">
+            <div class="img_settings_container" data-field-name="{{ $row->field }}" style="float:left;padding-right:15px;">
+                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->id }}" style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:5px;">
                 <a href="#" class="voyager-x remove-multi-image"></a>
             </div>
         @endforeach

--- a/resources/views/formfields/multiple_images.blade.php
+++ b/resources/views/formfields/multiple_images.blade.php
@@ -4,7 +4,7 @@
     @if($images != null)
         @foreach($images as $image)
             <div class="img_settings_container" data-field-name="{{ $row->field }}" style="float:left;padding-right:15px;">
-                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->id }}" style="width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:5px;">
+                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->id }}" style="max-width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:5px;">
                 <a href="#" class="voyager-x remove-multi-image"></a>
             </div>
         @endforeach


### PR DESCRIPTION
I notice that the "preview" images in edit-add form related to multi upload show images with the original sizes, then If we upload large photos form become unusable. I add some style to img and a float left to div container. I know that it's better to add a class in app.css but many formfields have inline css then for now I use the same method.