### PR TITLE
Fix Permissions Queries amount

### DIFF
--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -120,9 +120,6 @@ trait VoyagerUser
 
         if (!$this->role->relationLoaded('permissions')) {
             $this->role->load('permissions');
-        }
-
-        if (!$this->relationLoaded('roles.permissions')) {
             $this->load('roles.permissions');
         }
     }


### PR DESCRIPTION
**Symptom:**
Duplicate queries rising exponentially when the amount of `data_rows` goes higher.

**Example**
Tested on a fresh installation with dummy data on the categories browse page:
With **2** categories:
`72 statements were executed, 32 of which were duplicated, 40 unique`
With **100** categories:
`464 statements were executed, 424 of which were duplicated, 40 unique`

**Cause:**
[This](https://github.com/the-control-group/voyager/blob/1.x-dev/src/Traits/VoyagerUser.php#L125-L127) condition checks if the relationship and its content is loaded, and loads it if not.
The problem here is that its a distance relationship, so this wont work and `relationLoaded()` will always return false.

**Solution:**
Move loading `roles.permissions` inside the condition which tests if `role.permissions` was loaded

**Result:**
Same test-case as above:
With **2** categories:
`46 statements were executed, 6 of which were duplicated, 40 unique`
With **100** categories:
`46 statements were executed, 6 of which were duplicated, 40 unique`
(Yes its the same amount)

This kind of fixes issue #2805 but I think this is only part of a "bigger thing"