### PR TITLE
Fix slugify

### DIFF
--- a/resources/assets/js/slugify.js
+++ b/resources/assets/js/slugify.js
@@ -99,11 +99,15 @@
                              : str.charAt(i);
                 }
 
-                str = _slug
+                /*str = _slug
                     .replace(/^\s+|\s+$/g, '')      // Trim
                     .replace(/[^-\u0600-۾\w\d\$\*\(\)\'\!\_]/g, _sep)   // Remove invalid chars
                     .replace(/\s+/g, _sep)          // Replace spaces with separator
-                    .replace(/\-\-+/g, _sep);       // Replace multiple separators with single
+                    .replace(/\-\-+/g, _sep);       // Replace multiple separators with single*/
+                str = _slug
+                .replace(/[^a-z0-9]/g, _sep)
+                .replace(new RegExp('\\'+_sep+'\\'+_sep+'+', 'g'), _sep)
+                .replace(new RegExp('^\\'+_sep+'+|\\'+_sep+'+$', 'g'), '');
 
                 return str;
             },

--- a/resources/assets/js/slugify.js
+++ b/resources/assets/js/slugify.js
@@ -99,11 +99,6 @@
                              : str.charAt(i);
                 }
 
-                /*str = _slug
-                    .replace(/^\s+|\s+$/g, '')      // Trim
-                    .replace(/[^-\u0600-۾\w\d\$\*\(\)\'\!\_]/g, _sep)   // Remove invalid chars
-                    .replace(/\s+/g, _sep)          // Replace spaces with separator
-                    .replace(/\-\-+/g, _sep);       // Replace multiple separators with single*/
                 str = _slug
                 .replace(/[^a-z0-9]/g, _sep)
                 .replace(new RegExp('\\'+_sep+'\\'+_sep+'+', 'g'), _sep)


### PR DESCRIPTION
Cases tested (stolen from various issues around here):
**1:**
`Mời các bạn tối nay đến xem livestream “iPhone X”`
Becomes
`moi-cac-ban-toi-nay-den-xem-livestream-iphone-x`
**2:**
`!"§$%&/()=?`
Becomes
`dollar-and`
**3:**
`How much do you know about cryptocurrency?`
Becomes
`how-much-do-you-know-about-cryptocurrency`
**4:**
`Conditions générales d'utilisation`
Becomes
`conditions-generales-d-utilisation`


Fixes #2347, fixes #1698  and fixes #2493
Closes #2452