### PR TITLE
Various fixes

### DIFF
--- a/migrations/2018_03_16_000000_make_settings_value_nullable.php
+++ b/migrations/2018_03_16_000000_make_settings_value_nullable.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MakeSettingsValueNullable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->text('value')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->text('value')->nullable(false)->change();
+        });
+    }
+}

--- a/publishable/database/seeds/DataRowsTableSeeder.php
+++ b/publishable/database/seeds/DataRowsTableSeeder.php
@@ -603,7 +603,7 @@ class DataRowsTableSeeder extends Seeder
                 'edit'         => 1,
                 'add'          => 1,
                 'delete'       => 0,
-                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsTo","column":"role_id","key":"id","label":"name","pivot_table":"roles","pivot":"0"}',
+                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsTo","column":"role_id","key":"id","label":"display_name","pivot_table":"roles","pivot":"0"}',
                 'order'        => 10,
             ])->save();
         }
@@ -619,7 +619,7 @@ class DataRowsTableSeeder extends Seeder
                 'edit'         => 1,
                 'add'          => 1,
                 'delete'       => 0,
-                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsToMany","column":"id","key":"id","label":"name","pivot_table":"user_roles","pivot":"1"}',
+                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsToMany","column":"id","key":"id","label":"display_name","pivot_table":"user_roles","pivot":"1"}',
                 'order'        => 11,
             ])->save();
         }

--- a/publishable/lang/en/database.php
+++ b/publishable/lang/en/database.php
@@ -17,6 +17,7 @@ return [
     'delete_bread_before_table' => 'Please make sure to remove the BREAD on this table before deleting the table.',
     'delete_table_confirm'      => 'Yes, delete this table',
     'delete_table_question'     => 'Are you sure you want to delete the :table table?',
+    'editing_table'             => 'Editing table :table',
     'edit_table'                => 'Edit the :table table below',
     'edit_table_not_exist'      => 'The table you want to edit doesn\'t exist',
     'extra'                     => 'Extra',

--- a/publishable/lang/en/generic.php
+++ b/publishable/lang/en/generic.php
@@ -10,6 +10,7 @@ return [
     'are_you_sure'           => 'Are you sure',
     'are_you_sure_delete'    => 'Are you sure you want to delete',
     'auto_increment'         => 'Auto Increment',
+    'bread'                  => 'BREAD',
     'browse'                 => 'Browse',
     'builder'                => 'Builder',
     'bulk_delete'            => 'Bulk Delete',

--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -173,6 +173,7 @@
              * Add Menu
              */
             $('.add_item').click(function() {
+                $m_form.trigger('reset');
                 $m_modal.modal('show', {data: null});
             });
 

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -237,7 +237,18 @@
                                         @else
                                             <select name="field_input_type_{{ $data['field'] }}">
                                                 @foreach (Voyager::formFields() as $formField)
-                                                    <option value="{{ $formField->getCodename() }}" @if(isset($dataRow->type) && $dataRow->type == $formField->getCodename()){{ 'selected' }}@endif>
+                                                    @php
+                                                    if (
+                                                        (isset($dataRow->type) && $dataRow->type == $formField->getCodename())
+                                                        ||
+                                                        (!isset($dataRow->type) && $formField->getCodename() == 'text')
+                                                    ) {
+                                                        $selected = true;
+                                                    } else {
+                                                        $selected = false;
+                                                    }
+                                                    @endphp
+                                                    <option value="{{ $formField->getCodename() }}" {{ $selected ? 'selected' : '' }}>
                                                         {{ $formField->getName() }}
                                                     </option>
                                                 @endforeach

--- a/resources/views/tools/bread/index.blade.php
+++ b/resources/views/tools/bread/index.blade.php
@@ -77,7 +77,7 @@
                     <form action="{{ route('voyager.bread.delete', ['id' => null]) }}" id="delete_builder_form" method="POST">
                         {{ method_field('DELETE') }}
                         <input type="hidden" name="_token" value="{{ csrf_token() }}">
-                        <input type="submit" class="btn btn-danger" value="{{ __('voyager::bread.delete_table_bread_conf') }}">
+                        <input type="submit" class="btn btn-danger" value="{{ __('voyager::bread.delete_bread_conf') }}">
                     </form>
                     <button type="button" class="btn btn-outline pull-right" data-dismiss="modal">{{ __('voyager::generic.cancel') }}</button>
                 </div>

--- a/resources/views/tools/database/edit-add.blade.php
+++ b/resources/views/tools/database/edit-add.blade.php
@@ -1,4 +1,9 @@
 @extends('voyager::master')
+@if($db->action == 'update')
+    @section('page_title', __('voyager::database.editing_table', ['table' => $db->table->name]))
+@else
+    @section('page_title', __('voyager::database.create_new_table'))
+@endif
 
 @section('page_header')
     <h1 class="page-title">

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -93,10 +93,6 @@ class VoyagerSettingsController extends Controller
                 'group'   => $setting->group,
             ]);
 
-            if ($content === null && isset($setting->value)) {
-                $content = $setting->value;
-            }
-
             $key = preg_replace('/^'.str_slug($setting->group).'./i', '', $setting->key);
 
             $setting->group = $request->input(str_replace('.', '_', $setting->key).'_group');

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -204,7 +204,7 @@ class Voyager
     public function image($file, $default = '')
     {
         if (!empty($file)) {
-            return Storage::disk(config('voyager.storage.disk'))->url($file);
+            return str_replace('\\', '/', Storage::disk(config('voyager.storage.disk'))->url($file));
         }
 
         return $default;


### PR DESCRIPTION
This PR contains a bunch of small fixes:

1. `data_rows` default type now is `text` Fixes #2836 Fixes #2766 
2. Roles now display the `display_name` instead of `name`. Fixes #1742
3. `Voyager::image` returns backslashes when images were uploaded on Windows. Fixes #2834 
4. Missing language string in Database-edit-add
5. Settings value is now nullable and allows the user to empty it
6. Translation string `bread` in Bread-Browse was missing
7. Menu add-new modal had old values. Fixes #2732 
8. Wrong translation string Fixes #2848 