### PR TITLE
remove hardcoded readmore class and add custom classes through bread details

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -57,7 +57,8 @@
                                             <th></th>
                                         @endcan
                                         @foreach($dataType->browseRows as $row)
-                                        <th>
+                                            <?php $options = json_decode($row->details); ?>
+                                        <th class="{{ !empty($options->browse->thead->classes) ? implode(' ', $options->browse->thead->classes) : '' }}">
                                             @if ($isServerSide)
                                                 <a href="{{ $row->sortByUrl() }}">
                                             @endif
@@ -88,6 +89,7 @@
                                         @foreach($dataType->browseRows as $row)
                                             <td>
                                                 <?php $options = json_decode($row->details); ?>
+                                                <?php $classes = !empty($options->browse->tbody->classes) ? implode(' ', $options->browse->tbody->classes) : '' ?>
                                                 @if($row->type == 'image')
                                                     <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:100px">
                                                 @elseif($row->type == 'relationship')
@@ -137,10 +139,10 @@
                                                     <span class="badge badge-lg" style="background-color: {{ $data->{$row->field} }}">{{ $data->{$row->field} }}</span>
                                                 @elseif($row->type == 'text')
                                                     @include('voyager::multilingual.input-hidden-bread-browse')
-                                                    <div class="readmore">{{ mb_strlen( $data->{$row->field} ) > 200 ? mb_substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
+                                                    <div class="{{ $classes }}">{{ mb_strlen( $data->{$row->field} ) > 200 ? mb_substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
                                                 @elseif($row->type == 'text_area')
                                                     @include('voyager::multilingual.input-hidden-bread-browse')
-                                                    <div class="readmore">{{ mb_strlen( $data->{$row->field} ) > 200 ? mb_substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
+                                                    <div class="{{ $classes }}">{{ mb_strlen( $data->{$row->field} ) > 200 ? mb_substr($data->{$row->field}, 0, 200) . ' ...' : $data->{$row->field} }}</div>
                                                 @elseif($row->type == 'file' && !empty($data->{$row->field}) )
                                                     @include('voyager::multilingual.input-hidden-bread-browse')
                                                     @if(json_decode($data->{$row->field}))
@@ -157,7 +159,7 @@
                                                     @endif
                                                 @elseif($row->type == 'rich_text_box')
                                                     @include('voyager::multilingual.input-hidden-bread-browse')
-                                                    <div class="readmore">{{ mb_strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? mb_substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
+                                                    <div class="{{ $classes }}">{{ mb_strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? mb_substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
                                                 @elseif($row->type == 'coordinates')
                                                     @include('voyager::partials.coordinates-static-image')
                                                 @elseif($row->type == 'multiple_images')

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -88,8 +88,10 @@
                                         @endcan
                                         @foreach($dataType->browseRows as $row)
                                             <td>
-                                                <?php $options = json_decode($row->details); ?>
-                                                <?php $classes = !empty($options->browse->tbody->classes) ? implode(' ', $options->browse->tbody->classes) : '' ?>
+                                            @php
+                                                $options = json_decode($row->details);
+                                                $classes = !empty($options->browse->tbody->classes) ? implode(' ', $options->browse->tbody->classes) : '';
+                                            @endphp
                                                 @if($row->type == 'image')
                                                     <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:100px">
                                                 @elseif($row->type == 'relationship')


### PR DESCRIPTION
This solves #2861 and also adds the functionality to be able to add custom classes in the listing.

Adding this in bread details for a filed:

```
{
    "browse": {
        "thead": {
            "classes": [
                "col-sm-8"
            ]
        },
        "tbody": {
            "classes": [
                "text-primary",
                "text-uppercase"
            ]
        }
    }
}
```
Is going to add class="col-sm-8" to th tag, so we can format column widths, hide some columns for small screens and all that cool stuff.
And is going to add the other two classes to the associated td tag.

And of course who wants to use readmore can add that back.

I'm not sure about naming conventions, there is a display property already used to add  some custom properties to the add-edit template, maybe display_browse could be used in this case.