### PR TITLE
Fix migration role_id relationship

### DIFF
--- a/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -27,8 +27,8 @@ class AddUserRoleRelationship extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('role_id')->change();
             $table->dropForeign(['role_id']);
+            $table->integer('role_id')->change();
         });
     }
 }


### PR DESCRIPTION
When I rollback migrations, error display below
```
Illuminate\Database\QueryException  : SQLSTATE[HY000]: General error: 1832 Cannot change column 'role_id': used in a foreign key constraint 'users_role_id_foreign' (SQL: ALTER TABLE users CHANGE role_id role_id INT DEFAULT NULL)
```
I changed reverse migration code on `migrations/2017_11_26_013050_add_user_role_relationship.php`