### PR TITLE
Add resize option to thumbnails

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -290,13 +290,13 @@ abstract class Controller extends BaseController
                                             }
                                         }
                                     )->encode($file->getClientOriginalExtension(), $resize_quality);
-                                } elseif (isset($options->thumbnails) && isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
+                                } elseif (isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                                     $crop_width = $thumbnails->crop->width;
                                     $crop_height = $thumbnails->crop->height;
                                     $image = Image::make($file)
                                         ->fit($crop_width, $crop_height)
                                         ->encode($file->getClientOriginalExtension(), $resize_quality);
-                                } elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
+                                } elseif (isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
                                     $thumb_resize_width = null;
                                     $thumb_resize_height = null;
                                     if (isset($thumbnails->resize->width)) {
@@ -450,13 +450,13 @@ abstract class Controller extends BaseController
                                         }
                                     }
                                 )->encode($file->getClientOriginalExtension(), $resize_quality);
-                            } elseif (isset($options->thumbnails) && isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
+                            } elseif (isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                                 $crop_width = $thumbnails->crop->width;
                                 $crop_height = $thumbnails->crop->height;
                                 $image = Image::make($file)
                                     ->fit($crop_width, $crop_height)
                                     ->encode($file->getClientOriginalExtension(), $resize_quality);
-                            } elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
+                            } elseif (isset(isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
                                     $thumb_resize_width = null;
                                     $thumb_resize_height = null;
                                     if (isset($thumbnails->resize->width)) {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -296,6 +296,25 @@ abstract class Controller extends BaseController
                                     $image = Image::make($file)
                                         ->fit($crop_width, $crop_height)
                                         ->encode($file->getClientOriginalExtension(), $resize_quality);
+                                } elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
+                                    $thumb_resize_width = null;
+                                    $thumb_resize_height = null;
+                                    if (isset($thumbnails->resize->width)) {
+                                        $thumb_resize_width = $thumbnails->resize->width;
+                                    }
+                                    if (isset($thumbnails->resize->height)) {
+                                        $thumb_resize_height = $thumbnails->resize->height;
+                                    }
+                                    $image = Image::make($file)->resize(
+                                        $thumb_resize_width,
+                                        $thumb_resize_height,
+                                        function (Constraint $constraint) use ($options) {
+                                            $constraint->aspectRatio();
+                                            if (isset($options->upsize) && !$options->upsize) {
+                                                $constraint->upsize();
+                                            }
+                                        }
+                                    )->encode($file->getClientOriginalExtension(), $resize_quality);
                                 }
 
                                 Storage::disk(config('voyager.storage.disk'))->put(
@@ -437,7 +456,26 @@ abstract class Controller extends BaseController
                                 $image = Image::make($file)
                                     ->fit($crop_width, $crop_height)
                                     ->encode($file->getClientOriginalExtension(), $resize_quality);
-                            }
+                            }elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
+                                    $thumb_resize_width = null;
+                                    $thumb_resize_height = null;
+                                    if (isset($thumbnails->resize->width)) {
+                                        $thumb_resize_width = $thumbnails->resize->width;
+                                    }
+                                    if (isset($thumbnails->resize->height)) {
+                                        $thumb_resize_height = $thumbnails->resize->height;
+                                    }
+                                    $image = Image::make($file)->resize(
+                                        $thumb_resize_width,
+                                        $thumb_resize_height,
+                                        function (Constraint $constraint) use ($options) {
+                                            $constraint->aspectRatio();
+                                            if (isset($options->upsize) && !$options->upsize) {
+                                                $constraint->upsize();
+                                            }
+                                        }
+                                    )->encode($file->getClientOriginalExtension(), $resize_quality);
+                                }
 
                             Storage::disk(config('voyager.storage.disk'))->put(
                                 $path.$filename.'-'.$thumbnails->name.'.'.$file->getClientOriginalExtension(),

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -456,7 +456,7 @@ abstract class Controller extends BaseController
                                 $image = Image::make($file)
                                     ->fit($crop_width, $crop_height)
                                     ->encode($file->getClientOriginalExtension(), $resize_quality);
-                            }elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
+                            } elseif (isset($options->thumbnails) && isset($thumbnails->resize) && (isset($thumbnails->resize->width) || isset($thumbnails->resize->height))) {
                                     $thumb_resize_width = null;
                                     $thumb_resize_height = null;
                                     if (isset($thumbnails->resize->width)) {


### PR DESCRIPTION
There are no way to resize an image to make a thumbnail, you can only scale or crop original image.
With this PR I add the "resize" option also to thumbs.

usage:
```
    "thumbnails": [
        {
            "name": "resizedthumb",
            "resize": {
                "width": null,
                "height": "250"
            }
        }
    ]
```