### PR TITLE
Allow for the 'Translation' model to over extended/overridden

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -4,7 +4,7 @@ namespace TCG\Voyager\Traits;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use TCG\Voyager\Models\Translation;
+use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Translator;
 
 trait Translatable
@@ -30,7 +30,7 @@ trait Translatable
      */
     public function translations()
     {
-        return $this->hasMany(Translation::class, 'foreign_key', $this->getKeyName())
+        return $this->hasMany(Voyager::model('Translation'), 'foreign_key', $this->getKeyName())
             ->where('table_name', $this->getTable())
             ->whereIn('locale', config('voyager.multilingual.locales', []));
     }

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4,7 +4,7 @@ namespace TCG\Voyager;
 
 use ArrayAccess;
 use Illuminate\Database\Eloquent\Model;
-use TCG\Voyager\Models\Translation;
+use TCG\Voyager\Facades\Voyager;
 
 class Translator implements ArrayAccess
 {
@@ -59,7 +59,7 @@ class Translator implements ArrayAccess
             if ($attribute['exists']) {
                 $translation = $this->getTranslationModel($key);
             } else {
-                $translation = Translation::where('table_name', $this->model->getTable())
+                $translation = Voyager::model('Translation')->where('table_name', $this->model->getTable())
                     ->where('column_name', $key)
                     ->where('foreign_key', $this->model->getKey())
                     ->where('locale', $this->locale)
@@ -67,7 +67,7 @@ class Translator implements ArrayAccess
             }
 
             if (is_null($translation)) {
-                $translation = new Translation();
+                $translation = Voyager::model('Translation');
             }
 
             $translation->fill([
@@ -234,7 +234,7 @@ class Translator implements ArrayAccess
             return false;
         }
 
-        $translation = new Translation();
+        $translation = Voyager::model('Translation');
         $translation->fill([
             'table_name'  => $this->model->getTable(),
             'column_name' => $key,
@@ -275,7 +275,7 @@ class Translator implements ArrayAccess
         $translations = $this->model->getRelation('translations');
         $locale = $this->locale;
 
-        Translation::where('table_name', $this->model->getTable())
+        Voyager::model('Translation')->where('table_name', $this->model->getTable())
             ->where('column_name', $key)
             ->where('foreign_key', $this->model->getKey())
             ->where('locale', $locale)

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -25,8 +25,8 @@ use TCG\Voyager\Models\Post;
 use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\Setting;
 use TCG\Voyager\Models\User;
-use TCG\Voyager\Models\Translation;
 use TCG\Voyager\Traits\Translatable;
+use TCG\Voyager\Models\Translation;
 
 class Voyager
 {

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -25,6 +25,7 @@ use TCG\Voyager\Models\Post;
 use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\Setting;
 use TCG\Voyager\Models\User;
+use TCG\Voyager\Models\Translation;
 use TCG\Voyager\Traits\Translatable;
 
 class Voyager
@@ -52,17 +53,18 @@ class Voyager
     ];
 
     protected $models = [
-        'Category'   => Category::class,
-        'DataRow'    => DataRow::class,
-        'DataType'   => DataType::class,
-        'Menu'       => Menu::class,
-        'MenuItem'   => MenuItem::class,
-        'Page'       => Page::class,
-        'Permission' => Permission::class,
-        'Post'       => Post::class,
-        'Role'       => Role::class,
-        'Setting'    => Setting::class,
-        'User'       => User::class,
+        'Category'    => Category::class,
+        'DataRow'     => DataRow::class,
+        'DataType'    => DataType::class,
+        'Menu'        => Menu::class,
+        'MenuItem'    => MenuItem::class,
+        'Page'        => Page::class,
+        'Permission'  => Permission::class,
+        'Post'        => Post::class,
+        'Role'        => Role::class,
+        'Setting'     => Setting::class,
+        'User'        => User::class,
+        'Translation' => Translation::class,
     ];
 
     public $setting_cache = null;


### PR DESCRIPTION
Currently the 'Translation' model can't be extended/overriden using the Voyager::useModel() provider function (unlike other models). This PR resolves that issue.