### PR TITLE
Fix for spatial column type save error on mysq 5.7

### DIFF
--- a/src/Http/Controllers/ContentTypes/Coordinates.php
+++ b/src/Http/Controllers/ContentTypes/Coordinates.php
@@ -19,6 +19,6 @@ class Coordinates extends BaseType
         $lat = (float) $coordinates['lat'];
         $lng = (float) $coordinates['lng'];
 
-        return DB::raw("ST_GeomFromText(POINT({$lng} {$lat}))");
+        return DB::raw("ST_GeomFromText('POINT({$lng} {$lat})')");
     }
 }


### PR DESCRIPTION
This commit fixes the following error.
When saving spacial type column using `MySQL 5.7`, it returns `error near the spacial column value`.

Reproducing error
```
Voyager 1.x-dev
Mysql 5.7.14
PHP 7.2.3
```