### PR TITLE
Allows empty fields to be updated as null. Fixes #1402 

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -50,8 +50,8 @@ abstract class Controller extends BaseController
 
             // if the field for this row is absent from the request, continue
             // checkboxes will be absent when unchecked, thus they are the exception
-            if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
-                continue;
+            if (!$request->hasFile($row->field) && !$request->exists($row->field) && $row->type !== 'checkbox') {
+				continue;
             }
 
             $content = $this->getContentBasedOnType($request, $slug, $row);


### PR DESCRIPTION
With Voyager 1.0 I can't update a filled up BREAD field leaving it empty. It keeps it's last value instead.

In Voyager file "src\Http\Controllers\Controller.php", inside the method insertUpdateData() there is a condition that makes any empty field to be escaped from the loop process:
`!$request->has($row->field)` 

In Laravel ^5.4, $request->has() evals to false on empty fields, so I replaced it to:

`!$request->exists($row->field)`

$request->exists() returns true if the field is in request although it may be empty.

It seems to work fine in my bread tables, but I'm not sure if it may affect negatively any other kind of field. What do you think?

It fixes #1402 