### PR TITLE
Fix the BREAD json not removing issue on #2708

### DIFF
--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -410,7 +410,7 @@
                 _session.setMode("ace/mode/json");
                 if (textarea.val()) {
                     _session.setValue(JSON.stringify(JSON.parse(textarea.val()), null, 4));
-                    textarea.val('');
+                    // textarea.val('');
                 }
 
                 _session.setMode("ace/mode/" + mode);
@@ -429,6 +429,8 @@
                         if (_session.getValue()) {
                             // uglify JSON object and update textarea for submit purposes
                             textarea.val(JSON.stringify(JSON.parse(_session.getValue())));
+                        }else{
+                            textarea.val('');
                         }
                     }
                 });

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -410,6 +410,7 @@
                 _session.setMode("ace/mode/json");
                 if (textarea.val()) {
                     _session.setValue(JSON.stringify(JSON.parse(textarea.val()), null, 4));
+                    textarea.val('');
                 }
 
                 _session.setMode("ace/mode/" + mode);
@@ -425,6 +426,8 @@
                         }
                         toastr.error('{{ __('voyager::json.invalid_message') }}', '{{ __('voyager::json.validation_errors') }}', {"preventDuplicates": true, "preventOpenDuplicates": true});
                     } else {
+                        // ev.preventDefault();
+                        // ev.stopPropagation();
                         if (_session.getValue()) {
                             // uglify JSON object and update textarea for submit purposes
                             textarea.val(JSON.stringify(JSON.parse(_session.getValue())));

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -426,8 +426,6 @@
                         }
                         toastr.error('{{ __('voyager::json.invalid_message') }}', '{{ __('voyager::json.validation_errors') }}', {"preventDuplicates": true, "preventOpenDuplicates": true});
                     } else {
-                        // ev.preventDefault();
-                        // ev.stopPropagation();
                         if (_session.getValue()) {
                             // uglify JSON object and update textarea for submit purposes
                             textarea.val(JSON.stringify(JSON.parse(_session.getValue())));

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -410,7 +410,6 @@
                 _session.setMode("ace/mode/json");
                 if (textarea.val()) {
                     _session.setValue(JSON.stringify(JSON.parse(textarea.val()), null, 4));
-                    // textarea.val('');
                 }
 
                 _session.setMode("ace/mode/" + mode);


### PR DESCRIPTION
This PR fixes #2708.

 Textarea DOM is fillable with an empty string when submitting the form and there's nothing write on the editor.
So, if there was an old "additional details" it'll be removed.