### PR TITLE
fix: belongsToMany relationships can now be removed

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -51,7 +51,11 @@ abstract class Controller extends BaseController
             // if the field for this row is absent from the request, continue
             // checkboxes will be absent when unchecked, thus they are the exception
             if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
-                continue;
+                // if the field is a belongsToMany relationship, don't remove it
+                // if no content is provided, that means the relationships need to be removed
+                if (isset($options->type) && $options->type !== 'belongsToMany') {
+                    continue;
+                }
             }
 
             $content = $this->getContentBasedOnType($request, $slug, $row);


### PR DESCRIPTION
Removing all entries of a belongsToMany relationship in voyager results in the field being removed from the request that is to be saved in to the database. Therefore, a relationship cannot be removed, because that would render `$content` as `is_empty` and the current code then removes the `$row`. This fixes that issue.