### PR TITLE
Add classname to view button in browse template

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -186,7 +186,7 @@
                                                 </a>
                                             @endcan
                                             @can('read', $data)
-                                                <a href="{{ route('voyager.'.$dataType->slug.'.show', $data->{$data->getKeyName()}) }}" title="{{ __('voyager.generic.view') }}" class="btn btn-sm btn-warning pull-right">
+                                                <a href="{{ route('voyager.'.$dataType->slug.'.show', $data->{$data->getKeyName()}) }}" title="{{ __('voyager.generic.view') }}" class="btn btn-sm btn-warning pull-right view">
                                                     <i class="voyager-eye"></i> <span class="hidden-xs hidden-sm">{{ __('voyager.generic.view') }}</span>
                                                 </a>
                                             @endcan


### PR DESCRIPTION
Add a classname to the view button in the browse template to be consistent with the other buttons. This is expecially handy when trying to select the buttons with javascript.

I was selecting a button with javascript because i didn't want to override the whole template, unfortunately selecting the view button is a bit tricky. This makes this a lot easier. Additionally, this makes the classnames consistent with the other buttons.