### PR TITLE
Fix classname for view button in browse template

### DIFF
--- a/src/Actions/ViewAction.php
+++ b/src/Actions/ViewAction.php
@@ -22,7 +22,7 @@ class ViewAction extends AbstractAction
     public function getAttributes()
     {
         return [
-            'class' => 'btn btn-sm btn-warning pull-right edit',
+            'class' => 'btn btn-sm btn-warning pull-right view',
         ];
     }
 


### PR DESCRIPTION
Add the correct classname to the view button in the browse template to be consistent with the other buttons. This is expecially handy when trying to select the buttons with javascript.

I was selecting a button with javascript because i didn't want to override the whole template, unfortunately selecting the view button is a bit tricky. This makes this a lot easier and makes the classnames consistent with the other buttons.