### PR TITLE
Tagging feature for "belongs to many" relations

### DIFF
--- a/publishable/database/seeds/DataRowsTableSeeder.php
+++ b/publishable/database/seeds/DataRowsTableSeeder.php
@@ -170,7 +170,7 @@ class DataRowsTableSeeder extends Seeder
                 'edit'         => 1,
                 'add'          => 1,
                 'delete'       => 0,
-                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsToMany","column":"id","key":"id","label":"display_name","pivot_table":"user_roles","pivot":"1"}',
+                'details'      => '{"model":"TCG\\\Voyager\\\Models\\\Role","table":"roles","type":"belongsToMany","column":"id","key":"id","label":"display_name","pivot_table":"user_roles","pivot":"1","taggable":"0"}',
                 'order'        => 11,
             ])->save();
         }

--- a/publishable/lang/en/bread.php
+++ b/publishable/lang/en/bread.php
@@ -14,6 +14,7 @@ return [
     'error_creating_bread'   => 'Sorry it appears there may have been a problem creating this BREAD',
     'error_removing_bread'   => 'Sorry it appears there was a problem removing this BREAD',
     'error_updating_bread'   => 'Sorry it appears there may have been a problem updating this BREAD',
+    'error_tagging'          => 'Sorry it appears there may have been a problem creating the record. Please make sure your table has defaults for other fields.',
     'success_created_bread'  => 'Successfully created new BREAD',
     'success_remove_bread'   => 'Successfully removed BREAD from :datatype',
     'success_update_bread'   => 'Successfully updated the :datatype BREAD',

--- a/publishable/lang/en/database.php
+++ b/publishable/lang/en/database.php
@@ -68,6 +68,7 @@ return [
         'selection_details'    => 'Selection Details',
         'display_the'          => 'Display the',
         'store_the'            => 'Store the',
+        'allow_tagging'        => 'Allow Tagging',
         'easy_there'           => 'Easy there Captain',
         'before_create'        => 'Before you can create a new relationship you will need to create the BREAD first.<br> Then, return back to edit the BREAD and you will be able to add relationships.<br> Thanks.',
         'cancel'               => 'Cancel',

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -54,6 +54,44 @@ $(document).ready(function () {
     });
 
     $('select.select2').select2({width: '100%'});
+    $('select.select2-taggable').select2({
+        width: '100%',
+        tags: true,
+        createTag: function(params) {
+            var term = $.trim(params.term);
+
+            if (term === '') {
+                return null;
+            }
+        
+            return {
+                id: term,
+                text: term,
+                newTag: true
+            }
+        }
+    }).on('select2:selecting', function(e) {
+        var $el = $(this);
+        var route = $el.data('route');
+        var label = $el.data('label');
+        var errorMessage = $el.data('error-message');
+        var newTag = e.params.args.data.newTag;
+        
+        if (!newTag) return;
+
+        $el.select2('close');
+
+        $.post(route, {
+            [label]: e.params.args.data.text,
+        }).done(function(data) {
+            var newOption = new Option(e.params.args.data.text, data.data.id, false, true);
+            $el.append(newOption).trigger('change');
+        }).fail(function(error) {
+            toastr.error(errorMessage);
+        });
+
+        return false;
+    });
 
     $('.match-height').matchHeight();
 
@@ -125,6 +163,7 @@ $(document).ready(function () {
         var url = $(this).attr('action');
         var form = $(this);
         var data = new FormData(this);
+        data.set('_validate', '1');
 
         $.ajax({
             url: url,

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1735,7 +1735,7 @@ table.dataTable.no-footer{
               display:flex;
             }
         }
-        label{
+        & > label{
             height: 38px;
             background: #f1f1f1;
             padding: 7px 12px;
@@ -1804,7 +1804,7 @@ table.dataTable.no-footer{
             border: 1px solid #f1f1f1;
             margin-left: 10px;
         }
-        .relationship_key{
+        .relationship_key, .relationship_taggable{
           display:none;
         }
         .select2{
@@ -3170,7 +3170,7 @@ a.text-action{color:#a3afb7}a.text-action,a.text-action:focus,a.text-action:hove
             margin-right: 5px;
         }
     }
-    label{
+    :not(.toggle-group) > label {
         height: 38px;
         background: #f1f1f1;
         padding: 7px 12px;
@@ -3311,7 +3311,8 @@ a.text-action{color:#a3afb7}a.text-action,a.text-action:focus,a.text-action:hove
     .relationship_details_more{
         position:relative;
         margin-bottom:0px;
-        label{
+
+        :not(.toggle-group) > label {
             height: 38px;
             background: #f1f1f1;
             padding: 7px 12px;
@@ -3327,7 +3328,7 @@ a.text-action{color:#a3afb7}a.text-action,a.text-action:focus,a.text-action:hove
         .select2-container--default .select2-selection--single{
             border:1px solid #f1f1f1;
         }
-        .relationship_key{
+        .relationship_key, .relationship_taggable{
           display:none;
         }
         .well{

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -139,8 +139,15 @@
 	            @endif
 
 			@else
-
-				<select class="form-control select2" name="{{ $relationshipField }}[]" multiple>
+				<select
+					class="form-control @if($options->taggable == 'on') select2-taggable @else select2 @endif" 
+					name="{{ $relationshipField }}[]" multiple
+					@if($options->taggable == 'on')
+						data-route="{{ route('voyager.'.str_slug($options->table).'.store') }}"
+						data-label="{{$options->label}}"
+						data-error-message="{{__('voyager::bread.error_tagging')}}"
+					@endif
+				>
 					
 			            @php 
 					$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->table.'.'.$options->key)->all() : array();
@@ -151,7 +158,7 @@
 			                <option value="{{ $relationshipOption->{$options->key} }}" @if(in_array($relationshipOption->{$options->key}, $selected_values)){{ 'selected="selected"' }}@endif>{{ $relationshipOption->{$options->label} }}</option>
 			            @endforeach
 
-			    </select>
+				</select>
 
 			@endif
 

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -475,18 +475,21 @@
                     $(this).parent().parent().find('.relationshipField').show();
                     $(this).parent().parent().find('.relationshipPivot').hide();
                     $(this).parent().parent().find('.relationship_key').show();
+                    $(this).parent().parent().find('.relationship_taggable').hide();
                     $(this).parent().parent().find('.hasOneMany').removeClass('flexed');
                     $(this).parent().parent().find('.belongsTo').addClass('flexed');
                 } else if($(this).val() == 'hasOne' || $(this).val() == 'hasMany'){
                     $(this).parent().parent().find('.relationshipField').show();
                     $(this).parent().parent().find('.relationshipPivot').hide();
                     $(this).parent().parent().find('.relationship_key').hide();
+                    $(this).parent().parent().find('.relationship_taggable').hide();
                     $(this).parent().parent().find('.hasOneMany').addClass('flexed');
                     $(this).parent().parent().find('.belongsTo').removeClass('flexed');
                 } else {
                     $(this).parent().parent().find('.relationshipField').hide();
                     $(this).parent().parent().find('.relationshipPivot').css('display', 'flex');
                     $(this).parent().parent().find('.relationship_key').hide();
+                    $(this).parent().parent().find('.relationship_taggable').show();
                 }
             });
 

--- a/resources/views/tools/bread/relationship-new-modal.blade.php
+++ b/resources/views/tools/bread/relationship-new-modal.blade.php
@@ -62,9 +62,13 @@
 				                    <p class="relationship_key"><strong>{{ __('voyager::database.relationship.store_the') }} <span class="label_table_name"></span>: </strong>
 				                        <select name="relationship_key" class="rowDrop select2" data-table="{{ $tables[0] }}" data-selected="">
 				                        </select>
+									</p>
+
+									<p class="relationship_taggable"><strong>{{ __('voyager::database.relationship.allow_tagging') }}:</strong> <br>
+										<input type="checkbox" name="relationship_taggable" class="toggleswitch" data-on="{{ __('voyager::generic.yes') }}" data-off="{{ __('voyager::generic.no') }}">
 				                    </p>
 				                </div>
-				            </div>
+							</div>
 				        @else
 				        	<div class="col-md-12">
 				        		<h5><i class="voyager-rum-1"></i> {{ __('voyager::database.relationship.easy_there') }}</h5>

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -81,6 +81,13 @@
             <label class="relationship_key" style="@if($relationshipDetails->type == 'belongsTo' || $relationshipDetails->type == 'belongsToMany'){{ 'display:block' }}@endif">{{ __('voyager::database.relationship.store_the') }} <span class="label_table_name"></span></label>
             <select name="relationship_key_{{ $relationship['field'] }}" class="rowDrop select2 relationship_key" style="@if($relationshipDetails->type == 'belongsTo' || $relationshipDetails->type == 'belongsToMany'){{ 'display:block' }}@endif" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="@if(isset($relationshipDetails->key)){{ $relationshipDetails->key }}@endif">
             </select>
+            <br>
+            <label class="relationship_taggable" style="@if($relationshipDetails->type == 'belongsToMany'){{ 'display:block' }}@endif">
+                {{__('voyager::database.relationship.allow_tagging')}}
+            </label>
+            <span class="relationship_taggable" style="@if($relationshipDetails->type == 'belongsToMany'){{ 'display:block' }}@endif">
+                <input type="checkbox" name="relationship_taggable_{{ $relationship['field'] }}" class="toggleswitch" data-on="{{ __('voyager::generic.yes') }}" data-off="{{ __('voyager::generic.no') }}" {{$relationshipDetails->taggable == 'on' ? 'checked' : ''}}>
+            </span>
         </div>
     </div>
     <input type="hidden" value="0" name="field_required_{{ $relationship['field'] }}" checked="checked">

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -307,10 +307,14 @@ class VoyagerBaseController extends Controller
             return response()->json(['errors' => $val->messages()]);
         }
 
-        if (!$request->ajax()) {
+        if (!$request->has('_validate')) {
             $data = $this->insertUpdateData($request, $slug, $dataType->addRows, new $dataType->model_name());
 
             event(new BreadDataAdded($dataType, $data));
+
+            if ($request->ajax()) {
+                return response()->json(['success' => true, 'data' => $data]);
+            }
 
             return redirect()
                 ->route("voyager.{$dataType->slug}.index")

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -95,7 +95,7 @@ class VoyagerBreadController extends Controller
             if ($res) {
                 event(new BreadAdded($dataType, $data));
             }
-
+            
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
             return redirect()->route('voyager.bread.index')->with($this->alertException($e, 'Saving Failed'));
@@ -241,6 +241,7 @@ class VoyagerBreadController extends Controller
                 'label'       => $request->relationship_label,
                 'pivot_table' => $request->relationship_pivot,
                 'pivot'       => ($request->relationship_type == 'belongsToMany') ? '1' : '0',
+                'taggable'    => $request->relationship_taggable,
             ]);
 
             $newRow = new DataRow();

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -183,6 +183,7 @@ class DataType extends Model
                         'label'       => $requestData['relationship_label_'.$relationship],
                         'pivot_table' => $requestData['relationship_pivot_table_'.$relationship],
                         'pivot'       => ($requestData['relationship_type_'.$relationship] == 'belongsToMany') ? '1' : '0',
+                        'taggable'    => $requestData['relationship_taggable_'.$relationship] ?? '0',
                     ];
 
                     $requestData['field_details_'.$relationship] = json_encode($relationshipDetails);


### PR DESCRIPTION
This PR adds an option for belongsToMany relationships that enables the user to create new items directly using select2 and ajax.
Before using this, it's necessary to enable BREAD for the other table and make fields other than "label" nullable or give them default values.