### PR TITLE
fix use of voyager.prefix in AddBreadMenuItem

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -174,11 +174,19 @@ return [
     |
     */
 
-    // When a BREAD is added, create the Menu item using the BREAD properties.
-    'add_bread_menu_item' => true,
+    'bread' => [
+        // When a BREAD is added, create the Menu item using the BREAD properties.
+        'add_menu_item' => true,
 
-    // When a BREAD is added, create the related Permission.
-    'add_bread_permission' => true,
+        // which menu add item to
+        'default_menu' => 'admin',
+
+        // When a BREAD is added, create the related Permission.
+        'add_permission' => true,
+
+        // which role add premissions to
+        'default_role' => 'admin',
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/publishable/config/voyager_dummy.php
+++ b/publishable/config/voyager_dummy.php
@@ -113,6 +113,11 @@ return [
         'enabled' => false,
 
         /*
+         * Set whether or not the admin layout default is RTL.
+         */
+        'rtl' => false,
+
+        /*
          * Select default language
          */
         'default' => 'en',
@@ -171,11 +176,19 @@ return [
     |
     */
 
-    // When a BREAD is added, create the Menu item using the BREAD properties.
-    'add_bread_menu_item' => true,
+    'bread' => [
+        // When a BREAD is added, create the Menu item using the BREAD properties.
+        'add_menu_item' => true,
 
-    // When a BREAD is added, create the related Permission.
-    'add_bread_permission' => true,
+        // which menu add item to
+        'default_menu' => 'admin',
+
+        // When a BREAD is added, create the related Permission.
+        'add_permission' => true,
+
+        // which role add premissions to
+        'default_role' => 'admin',
+    ],
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Listeners/AddBreadMenuItem.php
+++ b/src/Listeners/AddBreadMenuItem.php
@@ -28,15 +28,16 @@ class AddBreadMenuItem
      */
     public function handle(BreadAdded $bread)
     {
-        if (config('voyager.add_bread_menu_item') && file_exists(base_path('routes/web.php'))) {
+        if (config('voyager.bread.add_menu_item') && file_exists(base_path('routes/web.php'))) {
             require base_path('routes/web.php');
 
-            $menu = Menu::where('name', 'admin')->firstOrFail();
+            $menu = Menu::where('name', config('voyager.bread.default_menu'))->firstOrFail();
 
             $menuItem = MenuItem::firstOrNew([
                 'menu_id' => $menu->id,
                 'title'   => $bread->dataType->display_name_plural,
-                'url'     => '/'.config('voyager.prefix', 'admin').'/'.$bread->dataType->slug,
+                'url'     => '',
+                'route'   => 'voyager.'.$bread->dataType->slug.'.index',
             ]);
 
             $order = Voyager::model('MenuItem')->highestOrderMenuItem();

--- a/src/Listeners/AddBreadPermission.php
+++ b/src/Listeners/AddBreadPermission.php
@@ -28,11 +28,11 @@ class AddBreadPermission
      */
     public function handle(BreadAdded $bread)
     {
-        if (config('voyager.add_bread_permission') && file_exists(base_path('routes/web.php'))) {
+        if (config('voyager.bread.add_permission') && file_exists(base_path('routes/web.php'))) {
             // Create permission
             //
             // Permission::generateFor(snake_case($bread->dataType->slug));
-            $role = Role::where('name', 'admin')->firstOrFail();
+            $role = Role::where('name', config('voyager.bread.default_role'))->firstOrFail();
 
             // Get permission for added table
             $permissions = Permission::where(['table_name' => $bread->dataType->name])->get()->pluck('id')->all();


### PR DESCRIPTION
removed hardcoded `admin` as menu in AddBreadMenuItem and role in AddBreadPermission and add configuration
added rtl to voyager_dummy config missed from #1989

**This PR changes two voyager config keys so I think config will need to be republished**