### PR TITLE
Safari not posting forms with empty files. Issue #3001

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -162,7 +162,20 @@ $(document).ready(function () {
 
         var url = $(this).attr('action');
         var form = $(this);
-        var data = new FormData(this);
+        var data = new FormData();
+
+        // Safari 11.1 Bug
+        // Filter out empty file just before the Ajax request
+        // https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari
+        for (i = 0; i < this.elements.length; i++) {
+            if (this.elements[i].type == 'file') {
+                if (this.elements[i].value == '') {
+                    continue;
+                }
+            }
+            data.append(this.elements[i].name, this.elements[i].value)
+        }
+
         data.set('_validate', '1');
 
         $.ajax({


### PR DESCRIPTION
There seems to be an bug in Safari 11 that is not sending forms with empty files.

https://stackoverflow.com/questions/49672992/ajax-request-fails-when-sending-formdata-including-empty-file-input-in-safari

Fixes #3001 