### PR TITLE
Use method chaining when interacting with the browser in some tests

### DIFF
--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -13,11 +13,11 @@ class LoginTest extends TestCase
 
     public function testSuccessfulLoginWithDefaultCredentials()
     {
-        $this->visit(route('voyager.login'));
-        $this->type('admin@admin.com', 'email');
-        $this->type('password', 'password');
-        $this->press(__('voyager::generic.login'));
-        $this->seePageIs(route('voyager.dashboard'));
+        $this->visit(route('voyager.login'))
+             ->type('admin@admin.com', 'email')
+             ->type('password', 'password')
+             ->press(__('voyager::generic.login'))
+             ->seePageIs(route('voyager.dashboard'));
     }
 
     public function testShowAnErrorMessageWhenITryToLoginWithWrongCredentials()

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -23,33 +23,33 @@ class RolesTest extends TestCase
      */
     public function testRoles()
     {
-        $this->visit(route('voyager.login'));
-        $this->type('admin@admin.com', 'email');
-        $this->type('password', 'password');
-        $this->press(__('voyager::generic.login'));
-        $this->seePageIs(route('voyager.dashboard'));
+        $this->visit(route('voyager.login'))
+             ->type('admin@admin.com', 'email')
+             ->type('password', 'password')
+             ->press(__('voyager::generic.login'))
+             ->seePageIs(route('voyager.dashboard'));
 
         // Adding a New Role
-        $this->visit(route('voyager.roles.create'));
-        $this->type('superadmin', 'name');
-        $this->type('Super Admin', 'display_name');
-        $this->press(__('voyager::generic.submit'));
-        $this->seePageIs(route('voyager.roles.index'));
-        $this->seeInDatabase('roles', ['name' => 'superadmin']);
+        $this->visit(route('voyager.roles.create'))
+             ->type('superadmin', 'name')
+             ->type('Super Admin', 'display_name')
+             ->press(__('voyager::generic.submit'))
+             ->seePageIs(route('voyager.roles.index'))
+             ->seeInDatabase('roles', ['name' => 'superadmin']);
 
         // Editing a Role
-        $this->visit(route('voyager.roles.edit', 2));
-        $this->type('regular_user', 'name');
-        $this->press(__('voyager::generic.submit'));
-        $this->seePageIs(route('voyager.roles.index'));
-        $this->seeInDatabase('roles', ['name' => 'regular_user']);
+        $this->visit(route('voyager.roles.edit', 2))
+             ->type('regular_user', 'name')
+             ->press(__('voyager::generic.submit'))
+             ->seePageIs(route('voyager.roles.index'))
+             ->seeInDatabase('roles', ['name' => 'regular_user']);
 
         // Editing a Role
-        $this->visit(route('voyager.roles.edit', 2));
-        $this->type('user', 'name');
-        $this->press(__('voyager::generic.submit'));
-        $this->seePageIs(route('voyager.roles.index'));
-        $this->seeInDatabase('roles', ['name' => 'user']);
+        $this->visit(route('voyager.roles.edit', 2))
+             ->type('user', 'name')
+             ->press(__('voyager::generic.submit'))
+             ->seePageIs(route('voyager.roles.index'))
+             ->seeInDatabase('roles', ['name' => 'user']);
 
         // Get the current super admin role
         $superadmin_role = Role::where('name', '=', 'superadmin')->first();


### PR DESCRIPTION
**Priority:** low

I came across some tests where we are interacting with the browser kit a lot. If we replace all those `$this` with method chaining, it will be easier to understand which actions are taken. The only downside is that it's harder to change the actions very quickly and adding comments to the actions. But how many times are we changing the admin page structure? So I don't think this is a problem.

There are some more tests, but these contains comments by each step. Removing `$this` would only make it worser.