### PR TITLE
Don't show a widget if it's not accessible for the current user

### DIFF
--- a/resources/views/dimmers.blade.php
+++ b/resources/views/dimmers.blade.php
@@ -3,10 +3,10 @@ $dimmers = \Arrilot\Widgets\Facade::group('voyager::dimmers');
 
 // Loop over the defined dashboard widgets. Get the related model and remove the
 // widget from the group if the current user hasn't the permission to read it.
-foreach (config('voyager.dashboard.widgets') as $widgetClass) {
+foreach (config('voyager.dashboard.widgets', []) as $widgetClass) {
     $relatedModel = app($widgetClass)->getRelatedModel();
 
-    if (! Auth::user()->can('read', $relatedModel)) {
+    if (! Auth::user()->can('browse', $relatedModel)) {
         $dimmers->removeByName($widgetClass);
     }
 }

--- a/resources/views/dimmers.blade.php
+++ b/resources/views/dimmers.blade.php
@@ -1,7 +1,17 @@
 @php
 $dimmers = \Arrilot\Widgets\Facade::group('voyager::dimmers');
-$count = $dimmers->count();
 
+// Loop over the defined dashboard widgets. Get the related model and remove the
+// widget from the group if the current user hasn't the permission to read it.
+foreach (config('voyager.dashboard.widgets') as $widgetClass) {
+    $relatedModel = app($widgetClass)->getRelatedModel();
+
+    if (! Auth::user()->can('read', $relatedModel)) {
+        $dimmers->removeByName($widgetClass);
+    }
+}
+
+$count = $dimmers->count();
 $classes = [
     'col-xs-12',
     'col-sm-'.($count >= 2 ? '6' : '12'),

--- a/resources/views/dimmers.blade.php
+++ b/resources/views/dimmers.blade.php
@@ -1,12 +1,9 @@
 @php
 $dimmers = \Arrilot\Widgets\Facade::group('voyager::dimmers');
 
-// Loop over the defined dashboard widgets. Get the related model and remove the
-// widget from the group if the current user hasn't the permission to read it.
+// Remove all the inaccessible widgets from the `voyager::dimmers` group.
 foreach (config('voyager.dashboard.widgets', []) as $widgetClass) {
-    $relatedModel = app($widgetClass)->getRelatedModel();
-
-    if (! Auth::user()->can('browse', $relatedModel)) {
+    if (!app($widgetClass)->isAccessible()) {
         $dimmers->removeByName($widgetClass);
     }
 }

--- a/src/Providers/VoyagerDummyServiceProvider.php
+++ b/src/Providers/VoyagerDummyServiceProvider.php
@@ -24,7 +24,7 @@ class VoyagerDummyServiceProvider extends ServiceProvider
     }
 
     /**
-     * Register widget.
+     * Register the dashboard widgets.
      */
     protected function registerWidgets()
     {

--- a/src/Widgets/PageDimmer.php
+++ b/src/Widgets/PageDimmer.php
@@ -35,4 +35,14 @@ class PageDimmer extends AbstractWidget
             'image' => voyager_asset('images/widget-backgrounds/03.jpg'),
         ]));
     }
+
+    /**
+     * Get the related model of this widget.
+     *
+     * @return \TCG\Voyager\Models\Page
+    */
+    public function getRelatedModel()
+    {
+        return Voyager::model('Page');
+    }
 }

--- a/src/Widgets/PageDimmer.php
+++ b/src/Widgets/PageDimmer.php
@@ -2,6 +2,7 @@
 
 namespace TCG\Voyager\Widgets;
 
+use Illuminate\Support\Facades\Auth;
 use Arrilot\Widgets\AbstractWidget;
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
@@ -37,12 +38,12 @@ class PageDimmer extends AbstractWidget
     }
 
     /**
-     * Get the related model of this widget.
+     * Determine if the widget is accessible.
      *
-     * @return \TCG\Voyager\Models\Page
+     * @return bool
     */
-    public function getRelatedModel()
+    public function isAccessible()
     {
-        return Voyager::model('Page');
+        return Auth::user()->can('browse', Voyager::model('Page'));
     }
 }

--- a/src/Widgets/PostDimmer.php
+++ b/src/Widgets/PostDimmer.php
@@ -2,6 +2,7 @@
 
 namespace TCG\Voyager\Widgets;
 
+use Illuminate\Support\Facades\Auth;
 use Arrilot\Widgets\AbstractWidget;
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
@@ -37,12 +38,12 @@ class PostDimmer extends AbstractWidget
     }
 
     /**
-     * Get the related model of this widget.
+     * Determine if the widget is accessible.
      *
-     * @return \TCG\Voyager\Models\Post
+     * @return bool
     */
-    public function getRelatedModel()
+    public function isAccessible()
     {
-        return Voyager::model('Post');
+        return \Auth::user()->can('browse', Voyager::model('Post'));
     }
 }

--- a/src/Widgets/PostDimmer.php
+++ b/src/Widgets/PostDimmer.php
@@ -35,4 +35,14 @@ class PostDimmer extends AbstractWidget
             'image' => voyager_asset('images/widget-backgrounds/02.jpg'),
         ]));
     }
+
+    /**
+     * Get the related model of this widget.
+     *
+     * @return \TCG\Voyager\Models\Post
+    */
+    public function getRelatedModel()
+    {
+        return Voyager::model('Post');
+    }
 }

--- a/src/Widgets/PostDimmer.php
+++ b/src/Widgets/PostDimmer.php
@@ -44,6 +44,6 @@ class PostDimmer extends AbstractWidget
     */
     public function isAccessible()
     {
-        return \Auth::user()->can('browse', Voyager::model('Post'));
+        return Auth::user()->can('browse', Voyager::model('Post'));
     }
 }

--- a/src/Widgets/UserDimmer.php
+++ b/src/Widgets/UserDimmer.php
@@ -35,4 +35,14 @@ class UserDimmer extends AbstractWidget
             'image' => voyager_asset('images/widget-backgrounds/01.jpg'),
         ]));
     }
+
+    /**
+     * Get the related model of this widget.
+     *
+     * @return \TCG\Voyager\Models\User
+    */
+    public function getRelatedModel()
+    {
+        return Voyager::model('User');
+    }
 }

--- a/src/Widgets/UserDimmer.php
+++ b/src/Widgets/UserDimmer.php
@@ -44,6 +44,6 @@ class UserDimmer extends AbstractWidget
     */
     public function isAccessible()
     {
-        return \Auth::user()->can('browse', Voyager::model('User'));
+        return Auth::user()->can('browse', Voyager::model('User'));
     }
 }

--- a/src/Widgets/UserDimmer.php
+++ b/src/Widgets/UserDimmer.php
@@ -2,6 +2,7 @@
 
 namespace TCG\Voyager\Widgets;
 
+use Illuminate\Support\Facades\Auth;
 use Arrilot\Widgets\AbstractWidget;
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
@@ -37,12 +38,12 @@ class UserDimmer extends AbstractWidget
     }
 
     /**
-     * Get the related model of this widget.
+     * Determine if the widget is accessible.
      *
-     * @return \TCG\Voyager\Models\User
+     * @return bool
     */
-    public function getRelatedModel()
+    public function isAccessible()
     {
-        return Voyager::model('User');
+        return \Auth::user()->can('browse', Voyager::model('User'));
     }
 }


### PR DESCRIPTION
**Priority:** medium

I have been working the whole day on a fix for #2275. I've tried everything, but this is the only solution that I can find.

Currently, if a user doesn't have the permission to browse the `posts` page for example, he can still see the `PostDimmer` widget. This pull request will fix that. It removes the widget from the `voyager::dimmers` group, if the user can't access it.

I decided not to wrap the `dimmer.blade.php` with `@can('read', $model)...@endcan`, because it would double check the permission. If you think, that this should be added, I can add it.

~I choosed to merge this pull request into the `v1.x-dev` branch, because now the widgets requires an `getRelatedModel` method.~

Some feedback would be highly apprenticed! Because I believe this PR is incomplete.

---

Fixes #2275
Fixes #2248