### PR TITLE
upload method modified to upload image with original name and no white space

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -186,7 +186,10 @@ class VoyagerMediaController extends Controller
                 'image/bmp',
                 'image/svg+xml',
             ];
-            $file = $request->file->store($request->upload_path, $this->filesystem);
+
+            $originalName = $request->file->getClientOriginalName();
+            $nameWithoutSpace = preg_replace('/\s+/', '-', $originalName);
+            $file = $request->file->storeAs($request->upload_path, $nameWithoutSpace, $this->filesystem);
 
             if (in_array($request->file->getMimeType(), $allowedImageMimeTypes)) {
                 $image = Image::make($realPath.$file);


### PR DESCRIPTION
This is important for SEO and was a problem that I wanted to solve, so I think it can be useful for other developers.

![upload-file-image](https://user-images.githubusercontent.com/2985150/39086822-90c86e4a-456e-11e8-8635-e71da267c8ef.PNG)
![code](https://user-images.githubusercontent.com/2985150/39086874-39a8f7aa-456f-11e8-9f5c-69ce9ac29a83.PNG)
