### PR TITLE
Database-Editor: Length input type = text for decimal-types

### DIFF
--- a/resources/views/tools/database/vue-components/database-column.blade.php
+++ b/resources/views/tools/database/vue-components/database-column.blade.php
@@ -13,7 +13,7 @@
     </td>
 
     <td>
-        <input v-model.number="column.length" type="number" min="0">
+        <input v-model.number="column.length" :type="lengthInputType" min="0">
     </td>
 
     <td>
@@ -57,6 +57,11 @@
 
 <script>
     Vue.component('database-column', {
+        data: function() {
+            return {
+                lengthInputType: 'number'
+            }
+        },
         props: {
             column: {
                 type: Object,
@@ -91,6 +96,8 @@
                 this.column.default = null;
 
                 this.column.type = type;
+
+                this.setLengthInputType();
             },
             onIndexTypeChange(event) {
                 if (this.column.name == '') {
@@ -102,7 +109,18 @@
                     old: this.index,
                     newType: event.target.value
                 });
+            },
+            setLengthInputType() {
+                var name = this.column.type.name;
+                if (name == 'double' || name == 'float' || name == 'decimal') {
+                    this.lengthInputType = 'text';
+                } else {
+                    this.lengthInputType = 'number';
+                }
             }
-        }
+        },
+        mounted() {
+            this.setLengthInputType();
+        },
     });
 </script>

--- a/resources/views/tools/database/vue-components/database-table-editor.blade.php
+++ b/resources/views/tools/database/vue-components/database-table-editor.blade.php
@@ -54,9 +54,10 @@
                 </thead>
                 <tbody>
                     <database-column
-                        v-for="column in table.columns"
+                        v-for="(column, index) in table.columns"
                         :column="column"
                         :index="getColumnsIndex(column.name)"
+                        :key="index"
                         @columnNameUpdated="renameColumn"
                         @columnDeleted="deleteColumn"
                         @indexAdded="addIndex"


### PR DESCRIPTION
When the column type was Float, Decimal or Double you were not able to insert any decimals in the length field.
This PR checks if the type is one of the above and makes the length-input-type text.

(Also fixed a small warning Vue throws because there was no `key` defined for a single `column`)