### PR TITLE
Cannot use TCG\Voyager\Facades\Voyager as Voyager

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -4,7 +4,7 @@ namespace TCG\Voyager;
 
 use ArrayAccess;
 use Illuminate\Database\Eloquent\Model;
-use TCG\Voyager\Facades\Voyager;
+//use TCG\Voyager\Facades\Voyager;
 
 class Translator implements ArrayAccess
 {


### PR DESCRIPTION
we facing error:
Cannot use TCG\Voyager\Facades\Voyager as Voyager because the name is already in use

Solution:
Remove "use TCG\Voyager\Facades\Voyager;"  (you no need to declare because both files are in same directory)
or
use as " use TCG\Voyager\Facades\Voyager as NewAlias; "