### PR TITLE
Made the autoloading of migrations optional

### DIFF
--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -97,7 +97,7 @@ class VoyagerServiceProvider extends ServiceProvider
 
         $this->loadTranslationsFrom(realpath(__DIR__.'/../publishable/lang'), 'voyager');
 
-        if(config('voyager.load_migrations') {
+        if(config('voyager.load_migrations')) {
             if (config('app.env') == 'testing') {
                 $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
             }

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -97,7 +97,7 @@ class VoyagerServiceProvider extends ServiceProvider
 
         $this->loadTranslationsFrom(realpath(__DIR__.'/../publishable/lang'), 'voyager');
 
-        if(config('voyager.load_migrations')) {
+        if (config('voyager.load_migrations', true)) {
             if (config('app.env') == 'testing') {
                 $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
             }

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -97,11 +97,13 @@ class VoyagerServiceProvider extends ServiceProvider
 
         $this->loadTranslationsFrom(realpath(__DIR__.'/../publishable/lang'), 'voyager');
 
-        if (config('app.env') == 'testing') {
-            $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
-        }
+        if(config('voyager.load_migrations') {
+            if (config('app.env') == 'testing') {
+                $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
+            }
 
-        $this->loadMigrationsFrom(realpath(__DIR__.'/../migrations'));
+            $this->loadMigrationsFrom(realpath(__DIR__.'/../migrations'));
+        }
 
         $this->registerGates();
 


### PR DESCRIPTION
Adding the autoloading of the migrations blacklists certain classes even if the multilingual functions are not used.

I use Laravel Translation manager for a part of the application, and since I cannot change the name of the table/class from Voyager anymore, it throws an error because the "CreateTranslationsTable" class already exists inside your autoloaded vendor-migrations directory.

It breaks backwards compatibility of any app that already used that class-name, as I had to go research around to problem-solve why my migrations suddenly wouldn't run.