### PR TITLE
Include function to automatic Route on FrontEnd

### DIFF
--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -20,3 +20,30 @@ if (!function_exists('voyager_asset')) {
         return asset(config('voyager.assets_path').'/'.$path, $secure);
     }
 }
+
+
+
+// support mutli language on frontend 
+// usage {{voyagerLink('url-to-cool-thing')}}
+
+if (!function_exists('voyagerLink')) {
+    function voyagerLink($path)
+    {
+        $def= config('app.locale');;
+        $lang= \App::getLocale();
+        if($lang!=$def){
+          $prefix = $lang."/";
+        }else{
+          $prefix = "";
+        }
+
+        if($path==""){
+          if($prefix)
+          return   '/'.$prefix.'/';
+          else
+          return '/';
+         }
+
+        return   '/'.$prefix.$path."/";
+    }
+}

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -29,7 +29,7 @@ if (!function_exists('voyager_asset')) {
 if (!function_exists('voyagerLink')) {
     function voyagerLink($path)
     {
-        $def= config('app.locale');;
+        $def= config('app.fallback_locale');;
         $lang= \App::getLocale();
         if($lang!=$def){
           $prefix = $lang."/";


### PR DESCRIPTION
for people want to use such function need to modify 
Route RouteServiceProvider.php 
to following 
```

<?php

namespace App\Providers;

use Illuminate\Support\Facades\Route;
use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
use Illuminate\Routing\Router;
use Illuminate\Http\Request;

class RouteServiceProvider extends ServiceProvider
{
    /**
     * This namespace is applied to your controller routes.
     *
     * In addition, it is set as the URL generator's root namespace.
     *
     * @var string
     */
    protected $namespace = 'App\Http\Controllers';

    /**
     * Define your route model bindings, pattern filters, etc.
     *
     * @return void
     */
    public function boot()
    {
        //

        parent::boot();
    }

    /**
     * Define the routes for the application.
     *
     * @return void
     */
    public function map(Router $router, Request $request)
    {
      $locale = $request->segment(1);
// i use english only if you use multi you shall create array of locale and check if is in array 

      if($locale=="en"){
        $this->app->setLocale($locale);
        $prefix = $locale;
      }else{
        $prefix="";
      }

        $this->mapApiRoutes();

        $this->mapWebRoutes($prefix);

        //
    }

    /**
     * Define the "web" routes for the application.
     *
     * These routes all receive session state, CSRF protection, etc.
     *
     * @return void
     */
    protected function mapWebRoutes($prefix)
    {
        if($prefix){
        Route::middleware('web')
             ->namespace($this->namespace)
             ->prefix($prefix)
             ->group(base_path('routes/web.php'));
           }else{
             Route::middleware('web')
                  ->namespace($this->namespace)
                  ->group(base_path('routes/web.php'));
           }
    }

    /**
     * Define the "api" routes for the application.
     *
     * These routes are typically stateless.
     *
     * @return void
     */
    protected function mapApiRoutes()
    {
        Route::prefix('api')
             ->middleware('api')
             ->namespace($this->namespace)
             ->group(base_path('routes/api.php'));
    }
}
```