### PR TITLE
Fix BelongsToMany relationships

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -57,7 +57,7 @@ abstract class Controller extends BaseController
             if ($row->type == 'relationship' && $options->type != 'belongsToMany') {
                 $row->field = @$options->column;
             }
-            
+
             // if the field for this row is absent from the request, continue
             // checkboxes will be absent when unchecked, thus they are the exception
             if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -54,21 +54,17 @@ abstract class Controller extends BaseController
         foreach ($rows as $row) {
             $options = json_decode($row->details);
 
-            // if the field for this row is absent from the request, continue
-            // checkboxes will be absent when unchecked, thus they are the exception
-            if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
-                // if the field is a belongsToMany relationship, don't remove it
-                // if no content is provided, that means the relationships need to be removed
-                if ((isset($options->type) && $options->type !== 'belongsToMany') || $row->field !== 'user_belongsto_role_relationship') {
-                    continue;
-                }
-            }
-
-            $content = $this->getContentBasedOnType($request, $slug, $row, $options);
-
             if ($row->type == 'relationship' && $options->type != 'belongsToMany') {
                 $row->field = @$options->column;
             }
+            
+            // if the field for this row is absent from the request, continue
+            // checkboxes will be absent when unchecked, thus they are the exception
+            if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
+                continue;
+            }
+
+            $content = $this->getContentBasedOnType($request, $slug, $row, $options);
 
             /*
              * merge ex_images and upload images


### PR DESCRIPTION
This commit fixes belongsTo relationships. 

Without this change, all belongsTo relationships are never persistet, because they are ignored (condition on line 63. the key in input is "*_belongsto_*_relationship", but `$row->field` is target column name, i.e. `user_id`.