### PR TITLE
Patch user roles creation

### DIFF
--- a/migrations/2017_11_26_015000_create_user_roles_table.php
+++ b/migrations/2017_11_26_015000_create_user_roles_table.php
@@ -13,12 +13,16 @@ class CreateUserRolesTable extends Migration
      */
     public function up()
     {
-        Schema::create('user_roles', function (Blueprint $table) {
+		Schema::table('users', function (Blueprint $table) {
+			$table->unsignedInteger('id')->change();
+		});	
+		
+		Schema::create('user_roles', function (Blueprint $table) {
             $table->integer('user_id')->unsigned()->index();
-            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->integer('role_id')->unsigned()->index();
+			$table->primary(['user_id', 'role_id']);
+			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
-            $table->primary(['user_id', 'role_id']);
         });
     }
 

--- a/migrations/2017_11_26_015000_create_user_roles_table.php
+++ b/migrations/2017_11_26_015000_create_user_roles_table.php
@@ -13,15 +13,15 @@ class CreateUserRolesTable extends Migration
      */
     public function up()
     {
-		Schema::table('users', function (Blueprint $table) {
-			$table->unsignedInteger('id')->change();
-		});	
-		
-		Schema::create('user_roles', function (Blueprint $table) {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedInteger('id')->change();
+        });
+
+        Schema::create('user_roles', function (Blueprint $table) {
             $table->integer('user_id')->unsigned()->index();
             $table->integer('role_id')->unsigned()->index();
-			$table->primary(['user_id', 'role_id']);
-			$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->primary(['user_id', 'role_id']);
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
             $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
         });
     }


### PR DESCRIPTION
- Laravel Version: 5.4
- Voyager Version: 1.1.0

In my migration list, users.id was not defined as unsigned integer, so the foreign key in user_roles table "user_id" could not be created due to this migration error:
![image](https://user-images.githubusercontent.com/25639840/39358773-89d6ac84-4a17-11e8-84d6-05b91f133d65.png)
