### PR TITLE
Add fix for removing many to many relationship

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -139,6 +139,7 @@
 	            @endif
 
 			@else
+				<input type="hidden" name="{{ $relationshipField }}" value=""/>
 				<select
 					class="form-control @if(isset($options->taggable) && $options->taggable == 'on') select2-taggable @else select2 @endif" 
 					name="{{ $relationshipField }}[]" multiple


### PR DESCRIPTION
Add a hidden field above the many to many relationship select, to make sure the field is always submitted.
This fixes the problem if you would want to delete all relations to the other object and this wouldn't work.