### PR TITLE
Possible fix for multi language issue #3089

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -312,11 +312,11 @@ trait Translatable
             );
 
             // Remove field hidden input
-            unset($request[$field.'_i18n']);
+            $request[$field.'_i18n'] = '';
         }
 
         // Remove language selector input
-        unset($request['i18n_selector']);
+        $request['i18n_selector'] = '';
 
         return $translations;
     }


### PR DESCRIPTION
`unset()` destroys fields inside `$request `object

Fixes #3089 