### PR TITLE
Add alias to Intervention Image class in MultipleImage content type

### DIFF
--- a/src/Http/Controllers/ContentTypes/MultipleImage.php
+++ b/src/Http/Controllers/ContentTypes/MultipleImage.php
@@ -5,7 +5,7 @@ namespace TCG\Voyager\Http\Controllers\ContentTypes;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\Constraint;
-use Intervention\Image\Facades\Image;
+use Intervention\Image\Facades\Image as InterventionImage;
 
 class MultipleImage extends BaseType
 {
@@ -18,7 +18,7 @@ class MultipleImage extends BaseType
         $files = $this->request->file($this->row->field);
 
         foreach ($files as $file) {
-            $image = Image::make($file);
+            $image = InterventionImage::make($file);
 
             $resize_width = null;
             $resize_height = null;
@@ -72,7 +72,7 @@ class MultipleImage extends BaseType
                             $thumb_resize_height = $thumb_resize_height * $scale;
                         }
 
-                        $image = Image::make($file)->resize(
+                        $image = InterventionImage::make($file)->resize(
                             $thumb_resize_width,
                             $thumb_resize_height,
                             function (Constraint $constraint) {
@@ -85,7 +85,7 @@ class MultipleImage extends BaseType
                     } elseif (isset($this->options->thumbnails) && isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                         $crop_width = $thumbnails->crop->width;
                         $crop_height = $thumbnails->crop->height;
-                        $image = Image::make($file)
+                        $image = InterventionImage::make($file)
                             ->fit($crop_width, $crop_height)
                             ->encode($file->getClientOriginalExtension(), $resize_quality);
                     }


### PR DESCRIPTION
When using the `Intervention\Image\Facades\Image` facade directly inside the `MultipleImage` content type, we are getting the following error: `Cannot use Intervention\Image\Facades\Image as Image because the name is already in use`. This error appears because there is already a class named `Image` in the same namespace (the content type: Image).

It was reported by @PinkuChanda at #3179 and solved by @emptynick.

I think merging this pull request without squashing will add @emptynick as Co Author in the commit.

---

Co-Authored-By: Christoph Schweppe
Fixes #3179
 