### PR TITLE
change voyager.user.namespace config behavior

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -13,7 +13,7 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role'                 => 'user',
-        'namespace'                    => App\User::class,
+        'namespace'                    => null,
         'default_avatar'               => 'users/default.png',
         'redirect'                     => '/admin',
     ],

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -13,6 +13,10 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role'                 => 'user',
+        // Set `namespace` to `null` to use `config('auth.providers.users.model')` value
+        // Set `namespace` to a class to override auth user model.
+        // However make sure the appointed class must ready to use before installing voyager.
+        // Otherwise `php artisan voyager:install` will fail with class not found error.
         'namespace'                    => null,
         'default_avatar'               => 'users/default.png',
         'redirect'                     => '/admin',

--- a/publishable/config/voyager_dummy.php
+++ b/publishable/config/voyager_dummy.php
@@ -13,7 +13,7 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role'                 => 'user',
-        'namespace'                    => App\User::class,
+        'namespace'                    => null,
         'default_avatar'               => 'users/default.png',
         'redirect'                     => '/admin',
     ],

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -81,7 +81,7 @@ class VoyagerServiceProvider extends ServiceProvider
     public function boot(Router $router, Dispatcher $event)
     {
         if (config('voyager.user.add_default_role_on_register')) {
-            $app_user = config('voyager.user.namespace');
+            $app_user = config('voyager.user.namespace') ?: config('auth.providers.users.model');
             $app_user::created(function ($user) {
                 if (is_null($user->role_id)) {
                     VoyagerFacade::model('User')->findOrFail($user->id)


### PR DESCRIPTION
change `voyager.user.namespace` config behavior to override, defaults to `auth.providers.users.model`.

Why do I do that? Try the following:
```
laravel new AwesomeApp
cd AwesomeApp
composer require tcg/voyager
php artisan app:name AwesomeApp
php artisan voyager:install

```

And it yells! Can't find `App\User`!

This PR should break no system, existing or in the future.  I think :smirk:
