### PR TITLE
fix broken translation in menu builder

### DIFF
--- a/resources/views/menu/admin.blade.php
+++ b/resources/views/menu/admin.blade.php
@@ -25,7 +25,7 @@
                 @include('voyager::multilingual.input-hidden', [
                     'isModelTranslatable' => true,
                     '_field_name'         => 'title'.$item->id,
-                    '_field_trans'        => htmlspecialchars(json_encode($item->getTranslationsOf('title')))
+                    '_field_trans'        => json_encode($item->getTranslationsOf('title'))
                 ])
             @endif
             <span>{{ $item->title }}</span> <small class="url">{{ $item->link() }}</small>

--- a/resources/views/menu/admin.blade.php
+++ b/resources/views/menu/admin.blade.php
@@ -15,7 +15,7 @@
                 data-icon_class="{{ $item->icon_class }}"
                 data-color="{{ $item->color }}"
                 data-route="{{ $item->route }}"
-                data-parameters="{{ htmlspecialchars(json_encode($item->parameters)) }}"
+                data-parameters="{{ json_encode($item->parameters) }}"
             >
                 <i class="voyager-edit"></i> {{ __('voyager::generic.edit') }}
             </div>


### PR DESCRIPTION
Discovered this bug and spent some time fixing it. 

To reproduce, enable multilingual, and in menu builder, all the menu names do not display, only the links. They also don't fill the input boxes when editing.

The fix is as simple as removing htmlspecialchars(), which I think is unnecessary here, as the data is from the database not user inputs.

Fixes #2731