### PR TITLE
Delete item error if there are empty file fields

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -400,8 +400,10 @@ class VoyagerBaseController extends Controller
 
         // Delete Files
         foreach ($dataType->deleteRows->where('type', 'file') as $row) {
-            foreach (json_decode($data->{$row->field}) as $file) {
-                $this->deleteFileIfExists($file->download_link);
+            if (count(json_decode($data->{$row->field}))) {
+                foreach (json_decode($data->{$row->field}) as $file) {
+                    $this->deleteFileIfExists($file->download_link);
+                }
             }
         }
     }


### PR DESCRIPTION
I can’t delete a bread item with empty file fields. Voyager try to delete files also if not present. 
Then the foreach fire an error: 
*Invalid argument supplied for foreach()*