### PR TITLE
Fix non-existing option in dropdown

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -124,7 +124,7 @@
                                                     @if($data->{$row->field . '_page_slug'})
                                                         <a href="{{ $data->{$row->field . '_page_slug'} }}">{!! $options->options->{$data->{$row->field}} !!}</a>
                                                     @else
-                                                        {!! $options->options->{$data->{$row->field}} !!}
+                                                        {!! $options->options->{$data->{$row->field}} or '' !!}
                                                     @endif
 
 


### PR DESCRIPTION
When an option is removed from a dropdown, but was previously selected, it was failing.
This adds an empty fallback value.
Fixes #1001 