### PR TITLE
Fix column not found when using additional_attributes w/ xMany relations

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -67,7 +67,7 @@
 				@php
 					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
 					$model = app($options->model);
-            		$selected_values = $model::where($options->column, '=', $relationshipData->id)->pluck($options->label)->all();
+            		$selected_values = $model::where($options->column, '=', $relationshipData->id)->get()->pluck($options->label)->all();
 				@endphp
 
 	            @if($view == 'browse')
@@ -118,7 +118,7 @@
 
 				@php
 					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
-	            	$selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->pluck($options->label)->all() : array();
+	            	$selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->get()->pluck($options->label)->all() : array();
 	            @endphp
 
 	            @if($view == 'browse')


### PR DESCRIPTION
Fix for belongsToMany and hasMany relationship display with
additional_attributes. You can now use additional_attributes with those
relations.
#2885

The fix get the model before plucking it. It caused error because when
you pluck the query builder, it affects the mysql query. When you use
additional attribute, it doesn’t exist in the database and result with
a `SQLSTATE[42S22]: Column not found: 1054 Unknown column ‘youradditionalattribute’ in 'field list’` error…

This is a fresher repost from #3233 