### PR TITLE
Changing exception type for canOrFail

### DIFF
--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use TCG\Voyager\Actions\DeleteAction;
 use TCG\Voyager\Actions\EditAction;
 use TCG\Voyager\Actions\ViewAction;
@@ -264,7 +264,7 @@ class Voyager
     public function canOrFail($permission)
     {
         if (!$this->can($permission)) {
-            throw new UnauthorizedHttpException(null);
+            throw new AccessDeniedHttpException();
         }
 
         return true;


### PR DESCRIPTION
`UnauthorizedAccessException` cannot accept a null parameter, else it'll throw an error.  `AccessDeniedHttpException` is a better option anyway.

Fixes #3081 