### PR TITLE
Resizeable support for multiple images

### DIFF
--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -22,6 +22,17 @@ trait Resizable
         // We take image from posts field
         $image = $this->attributes[$attribute];
 
+        return $this->get_thumbnail($image, $type);
+    }
+
+    /**
+     * Generate thumbnail URL
+     * @param $image
+     * @param $type
+     * @return string
+     */
+    public function get_thumbnail($image, $type)
+    {
         // We need to get extension type ( .jpeg , .png ...)
         $ext = pathinfo($image, PATHINFO_EXTENSION);
 

--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -26,9 +26,11 @@ trait Resizable
     }
 
     /**
-     * Generate thumbnail URL
+     * Generate thumbnail URL.
+     *
      * @param $image
      * @param $type
+     *
      * @return string
      */
     public function get_thumbnail($image, $type)


### PR DESCRIPTION
This will allow us to pass any image path and generate the thumbnail using `get_thumbnail`. This is useful when using it inside of multiple images array / input type. For example:
```
@foreach($posts as $post)
    @foreach($post->images as $image)
        <img src="{{Voyager::image($post->get_thumbnail($image, 'small'))}}" />
    @endforeach
@endforeach
```

If you are using multiple images input type, you can optional cast your images attribute
```
use TCG\Voyager\Traits\Resizable;

class Post extends Model
{
    use Resizable;

    protected $casts = [
        'images' => 'array',
    ];
}
```