### PR TITLE
Fix styling issue on Edit Role page

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -4493,6 +4493,13 @@ p#the_plugin_name{
     padding-right:0px;
 }
 
+.page-content .form-edit-add ul.permissions {
+    list-style-type: none;
+    li {
+        list-style-type: none;
+    }
+}
+
 .app-container .content-container .side-menu .navbar-header .navbar-brand .title{
   text-transform: uppercase;
   position:relative;


### PR DESCRIPTION
When viewing the Edit Role page, the li and ul list styling shows partially under the checkboxes, this removes the list style for them to resolve this issue.

Before:
![screen shot 2018-06-07 at 14 43 56](https://user-images.githubusercontent.com/6931281/41104175-b27d15ae-6a62-11e8-826e-329248a0e85e.png)
[This screenshot](https://user-images.githubusercontent.com/6931281/41104262-db18c1fc-6a62-11e8-9ffc-501e2f8a4402.png) shows the issue more clearly, as I have removed the negative 20px margin-left for the checkbox on it so that it shows exactly what's underneath the checkbox.

After:
![screen shot 2018-06-07 at 14 46 41](https://user-images.githubusercontent.com/6931281/41104190-b986bd5a-6a62-11e8-908c-1cb78e87bf4f.png)
