### PR TITLE
Use slug instead of slugified table name

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -148,7 +148,7 @@
 					class="form-control @if(isset($options->taggable) && $options->taggable == 'on') select2-taggable @else select2 @endif" 
 					name="{{ $relationshipField }}[]" multiple
 					@if(isset($options->taggable) && $options->taggable == 'on')
-                        data-route="{{ route('voyager.' . $dataType->slug . '.store') }}"
+						data-route="{{ route('voyager.' . $dataType->slug . '.store') }}"
 						data-label="{{$options->label}}"
 						data-error-message="{{__('voyager::bread.error_tagging')}}"
 					@endif

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -148,7 +148,7 @@
 					class="form-control @if(isset($options->taggable) && $options->taggable == 'on') select2-taggable @else select2 @endif" 
 					name="{{ $relationshipField }}[]" multiple
 					@if(isset($options->taggable) && $options->taggable == 'on')
-						data-route="{{ route('voyager.'.str_slug($options->table).'.store') }}"
+                        data-route="{{ route('voyager.' . $dataType->slug . '.store') }}"
 						data-label="{{$options->label}}"
 						data-error-message="{{__('voyager::bread.error_tagging')}}"
 					@endif


### PR DESCRIPTION
The `relationship.blade.php` view was using _slugified table name_ instead of the stored _URL Slug_ to access the store view.
This caused error when personalising BREAD url slug and having a belongsToMany relation pointing to it in an other BREAD.

### If you want to reproduce:

1. Create a BREAD with custom URL Slug (B1)
1. Create a BREAD (B2) with a belongs to many relation to the table of B1
1. Go to B2 and try to edit one row of data

### This throws this error:
`Route [voyager.slugified-table-name.store] not defined. (View: vendor/tcg/voyager/resources/views/formfields/relationship.blade.php) (View: vendor/tcg/voyager/resources/views/formfields/relationship.blade.php)`