### PR TITLE
[WIP] Add the ability to configure a custom base direction per user

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -13,6 +13,8 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role'                 => 'user',
+        // available directions: `ltr` or `rtl`
+        'default_base_direction'       => 'ltr',
         // Set `namespace` to `null` to use `config('auth.providers.users.model')` value
         // Set `namespace` to a class to override auth user model.
         // However make sure the appointed class must ready to use before installing voyager.

--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -13,7 +13,7 @@ return [
     'user' => [
         'add_default_role_on_register' => true,
         'default_role'                 => 'user',
-        // available directions: `ltr` or `rtl`
+        // Available directions: `ltr` or `rtl`.
         'default_base_direction'       => 'ltr',
         // Set `namespace` to `null` to use `config('auth.providers.users.model')` value
         // Set `namespace` to a class to override auth user model.

--- a/publishable/database/seeds/DataRowsTableSeeder.php
+++ b/publishable/database/seeds/DataRowsTableSeeder.php
@@ -191,6 +191,22 @@ class DataRowsTableSeeder extends Seeder
             ])->save();
         }
 
+        $dataRow = $this->dataRow($userDataType, 'base_direction');
+        if (!$dataRow->exists) {
+            $dataRow->fill([
+                'type'         => 'text',
+                'display_name' => 'Base Direction',
+                'required'     => 0,
+                'browse'       => 0,
+                'read'         => 1,
+                'edit'         => 1,
+                'add'          => 1,
+                'delete'       => 0,
+                'details'      => '',
+                'order'        => 13,
+            ])->save();
+        }
+
         $dataRow = $this->dataRow($userDataType, 'settings');
         if (!$dataRow->exists) {
             $dataRow->fill([
@@ -203,7 +219,7 @@ class DataRowsTableSeeder extends Seeder
                 'add'          => 0,
                 'delete'       => 0,
                 'details'      => '',
-                'order'        => 12,
+                'order'        => 14,
             ])->save();
         }
 

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -97,6 +97,24 @@
                                     @endforeach
                                 </select>
                             </div>
+
+                            @php
+                                if (isset($dataTypeContent->base_direction)) {
+                                    $selectedBaseDirection = $dataTypeContent->base_direction;
+                                } else {
+                                    $selectedBaseDirection = config('voyager.user.default_base_direction', 'LTR');
+                                }
+                            @endphp
+                            @dump($dataTypeContent->settings)
+                            <div class="form-group">
+                                <label for="locale">Base Direction</label>
+                                <select class="form-control select2" id="base_direction" name="base_direction">
+                                    @foreach (Voyager::getBaseDirections() as $baseDirection)
+                                    <option value="{{ $baseDirection }}"
+                                    {{ ($baseDirection == $selectedBaseDirection ? 'selected' : '') }}>{{ $baseDirection }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -106,7 +106,7 @@
                                 }
                             @endphp
                             <div class="form-group">
-                                <label for="locale">Base Direction</label>
+                                <label for="base_direction">Base Direction</label>
                                 <select class="form-control select2" id="base_direction" name="base_direction">
                                     @foreach (Voyager::getBaseDirections() as $baseDirection)
                                     <option value="{{ $baseDirection }}"

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -105,7 +105,6 @@
                                     $selectedBaseDirection = config('voyager.user.default_base_direction', 'LTR');
                                 }
                             @endphp
-                            @dump($dataTypeContent->settings)
                             <div class="form-group">
                                 <label for="locale">Base Direction</label>
                                 <select class="form-control select2" id="base_direction" name="base_direction">

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -26,7 +26,7 @@ class VoyagerAdminMiddleware
             }
 
             if (isset($user->base_direction)) {
-                config()->set('voyager.multilingual.rtl', $user->base_direction === 'RTL');
+                config()->set('voyager.multilingual.rtl', $user->base_direction === 'rtl');
             }
 
             return $user->hasPermission('browse_admin') ? $next($request) : redirect('/');

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -20,8 +20,13 @@ class VoyagerAdminMiddleware
     {
         if (!Auth::guest()) {
             $user = auth()->user();
+
             if (isset($user->locale)) {
                 app()->setLocale($user->locale);
+            }
+
+            if (isset($user->base_direction)) {
+                config()->set('voyager.multilingual.rtl', $user->base_direction === 'RTL');
             }
 
             return $user->hasPermission('browse_admin') ? $next($request) : redirect('/');

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -13,6 +13,22 @@ class User extends Authenticatable implements UserContract
     use VoyagerUser,
         HasRelationships;
 
+    /**
+     * Base directions.
+     */
+    const BASE_DIRECTION_LTR = 'LTR';
+    const BASE_DIRECTION_RTL = 'RTL';
+
+    /**
+     * Collection of base directions.
+     *
+     * @var array
+     */
+    public static $baseDirections = [
+        self::BASE_DIRECTION_LTR,
+        self::BASE_DIRECTION_RTL
+    ];
+
     protected $guarded = [];
 
     protected $casts = [
@@ -41,5 +57,31 @@ class User extends Authenticatable implements UserContract
     public function getLocaleAttribute()
     {
         return $this->settings['locale'];
+    }
+
+    /**
+     * Get the user's base direction.
+     *
+     * @return string
+     */
+    public function getBaseDirectionAttribute()
+    {
+        return $this->settings['base_direction'];
+    }
+
+    /**
+     * Set the user's base direction.
+     *
+     * @param string $direction
+     * @return void
+     */
+    public function setBaseDirectionAttribute($direction)
+    {
+        // Throw error if given direction is not a valid base direction
+        if (! in_array(strtoupper($direction), self::$baseDirections)) {
+            return;
+        }
+
+        $this->attributes['settings'] = collect($this->settings)->merge(['base_direction' => $direction]);
     }
 }

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -16,8 +16,8 @@ class User extends Authenticatable implements UserContract
     /**
      * Base directions.
      */
-    const BASE_DIRECTION_LTR = 'LTR';
-    const BASE_DIRECTION_RTL = 'RTL';
+    const BASE_DIRECTION_LTR = 'ltr';
+    const BASE_DIRECTION_RTL = 'rtl';
 
     /**
      * Collection of base directions.
@@ -78,7 +78,7 @@ class User extends Authenticatable implements UserContract
     public function setBaseDirectionAttribute($direction)
     {
         // Throw error if given direction is not a valid base direction
-        if (! in_array(strtoupper($direction), self::$baseDirections)) {
+        if (! in_array(strtolower($direction), self::$baseDirections)) {
             return;
         }
 

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -382,4 +382,14 @@ class Voyager
     {
         return array_diff(scandir(realpath(__DIR__.'/../publishable/lang')), ['..', '.']);
     }
+
+    /**
+     * Get a collection of available base directions.
+     *
+     * @return array
+     */
+    public function getBaseDirections()
+    {
+        return User::$baseDirections;
+    }
 }


### PR DESCRIPTION
This pull request will make it possible to configure a custom base direction per user. Each user can change the direction inside his profile.

Instead of calling it `dir` (like in HTML), I decided to call it `base direction` to be more descriptive.

It's a work in progress, so I'm interested in some feedback from the maintainers and of course other contributors.

Some things where I want to think about:
- Make this feature optional (should a user be able to change his base direction)
- Create a hook instead of adding it to the core
- A cleaner solution for: `config()->set('voyager.multilingual.rtl', $user->base_direction === 'rtl');`

I also had an idea about determining the direction based upon the user's locale. I'll keep you informed!

If you're not interested in this feature, please let me know!
Thanks!