### PR TITLE
now you are not forced to make table name in plural

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -112,7 +112,7 @@ abstract class Controller extends BaseController
             }
         }
 
-        $data->save();
+        $data->setTable($slug)->save();
 
         // Save translations
         if (count($translations) > 0) {

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -50,7 +50,7 @@ class VoyagerBaseController extends Controller
             $relationships = $this->getRelationships($dataType);
 
             $model = app($dataType->model_name);
-            $query = $model::select('*')->with($relationships);
+            $query = $model->from($dataType->name)->with($relationships);
 
             // If a column has a relationship associated with it, we do not want to show that field
             $this->removeRelationshipField($dataType, 'browse');


### PR DESCRIPTION
You always need to specify the table name as plural but now you are not forced to do that.