### PR TITLE
Add a choice to keep original filename after uploading

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -223,4 +223,8 @@ return [
          'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM', 11),
      ],
 
+     'media' => [
+         'keep_filename' => false,
+     ],
+
 ];

--- a/publishable/config/voyager_dummy.php
+++ b/publishable/config/voyager_dummy.php
@@ -221,4 +221,8 @@ return [
          'zoom' => env('GOOGLE_MAPS_DEFAULT_ZOOM', 11),
      ],
 
+     'media' => [
+         'keep_filename' => false,
+     ],
+
 ];

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -186,7 +186,20 @@ class VoyagerMediaController extends Controller
                 'image/bmp',
                 'image/svg+xml',
             ];
-            $file = $request->file->store($request->upload_path, $this->filesystem);
+
+            $baseOriginalFilename = basename($request->file->getClientOriginalName());
+
+            if (config('voyager.media.keep_filename')
+                && !Storage::disk($this->filesystem)->exists("{$request->upload_path}/{$baseOriginalFilename}")
+            ) {
+                $file = $request->file->storeAs(
+                    $request->upload_path,
+                    $baseOriginalFilename,
+                    $this->filesystem
+                );
+            } else {
+                $file = $request->file->store($request->upload_path, $this->filesystem);
+            }
 
             if (in_array($request->file->getMimeType(), $allowedImageMimeTypes)) {
                 $image = Image::make($realPath.$file);


### PR DESCRIPTION
Default behavior still is application will introduce a random name for uploaded file.
We add a choice/config so that users could have their application try to keep original uploaded file name, unless that name is duplicated.

This code works well in my system for a while, even with S3 Adapter.

Thanks.