### PR TITLE
Relationship formfield with Ajax Pagination and Infinite Scrolling

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -1,182 +1,210 @@
 @if(isset($options->model) && isset($options->type))
+	
+	@if(class_exists($options->model))
 
-    @if(class_exists($options->model))
+		@php $relationshipField = $row->field; @endphp
 
-        @php $relationshipField = $row->field; @endphp
+		@if($options->type == 'belongsTo')
 
-        @if($options->type == 'belongsTo')
+			@if(isset($view) && ($view == 'browse' || $view == 'read'))
 
-            @if(isset($view) && ($view == 'browse' || $view == 'read'))
+				@php 
+					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
+					$model = app($options->model);
+					if (method_exists($model, 'getRelationship')) {
+						$query = $model::getRelationship($relationshipData->{$options->column});
+					} else {
+						$query = $model::find($relationshipData->{$options->column});
+					}
+            	@endphp
 
-                @php
-                    $relationshipData = (isset($data)) ? $data : $dataTypeContent;
-                    $model = app($options->model);
-                    if (method_exists($model, 'getRelationship')) {
-                        $query = $model::getRelationship($relationshipData->{$options->column});
-                    } else {
-                        $query = $model::find($relationshipData->{$options->column});
-                    }
-                @endphp
+            	@if(isset($query))
+					<p>{{ $query->{$options->label} }}</p>
+				@else
+					<p>{{__('voyager::generic.no_results')}}</p>
+				@endif
 
-                @if(isset($query))
-                    <p>{{ $query->{$options->label} }}</p>
-                @else
-                    <p>No results</p>
-                @endif
+			@else
+			
+				<select class="form-control select2 select2ajax" name="{{ $options->column }}" 
+					data-model="{{ $options->model }}" data-key="{{ $options->key }}" data-label="{{ $options->label }}" data-perpage="20">
+					@php 
+						$model = app($options->model);
+						$selected_value = $model->where($options->key, $dataTypeContent->{$options->column})->pluck($options->label, $options->key);
+					@endphp
 
-            @else
+					@if($row->required === 0)
+						<option value="">{{__('voyager::generic.none')}}</option>
+					@endif
+					
+					@if($selected_value)
+						<option value="{{ $dataTypeContent->{$options->column} }}" selected="selected">{{ $selected_value[$dataTypeContent->{$options->column}] }}</option>
+					@endif
+				</select>
 
-                <select class="form-control select2" name="{{ $options->column }}">
-                    @php
-                        $model = app($options->model);
-                        $query = $model::all();
-                    @endphp
+			@endif
+		
+		@elseif($options->type == 'hasOne')
 
-                    @if($row->required === 0)
-                        <option value="">{{__('voyager::generic.none')}}</option>
-                    @endif
+			@php 
 
-                    @foreach($query as $relationshipData)
-                        <option value="{{ $relationshipData->{$options->key} }}" @if($dataTypeContent->{$options->column} == $relationshipData->{$options->key}){{ 'selected="selected"' }}@endif>{{ $relationshipData->{$options->label} }}</option>
-                    @endforeach
-                </select>
+				$relationshipData = (isset($data)) ? $data : $dataTypeContent;
+			
+				$model = app($options->model);
+        		$query = $model::where($options->column, '=', $relationshipData->id)->first();
+			
+			@endphp
 
-            @endif
+			@if(isset($query))
+				<p>{{ $query->{$options->label} }}</p>
+			@else
+				<p>None results</p>
+			@endif
 
-        @elseif($options->type == 'hasOne')
+		@elseif($options->type == 'hasMany')
 
-            @php
+			@if(isset($view) && ($view == 'browse' || $view == 'read'))
 
-                $relationshipData = (isset($data)) ? $data : $dataTypeContent;
+				@php
+					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
+					$model = app($options->model);
+            		$selected_values = $model::where($options->column, '=', $relationshipData->id)->pluck($options->label)->all();
+				@endphp
 
-                $model = app($options->model);
-                $query = $model::where($options->column, '=', $relationshipData->id)->first();
+	            @if($view == 'browse')
+	            	@php
+	            		$string_values = implode(", ", $selected_values); 
+	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; } 
+	            	@endphp
+	            	@if(empty($selected_values))
+		            	<p>{{__('voyager::generic.no_results')}}</p>
+		            @else
+	            		<p>{{ $string_values }}</p>
+	            	@endif
+	            @else
+	            	@if(empty($selected_values))
+		            	<p>{{__('voyager::generic.no_results')}}</p>
+		            @else
+		            	<ul>
+			            	@foreach($selected_values as $selected_value)
+			            		<li>{{ $selected_value }}</li>
+			            	@endforeach
+			            </ul>
+			        @endif
+	            @endif
 
-            @endphp
+			@else
 
-            @if(isset($query))
-                <p>{{ $query->{$options->label} }}</p>
-            @else
-                <p>None results</p>
-            @endif
+				@php
+					$model = app($options->model);
+            		$query = $model::where($options->column, '=', $dataTypeContent->id)->get();
+				@endphp
 
-        @elseif($options->type == 'hasMany')
+				@if(isset($query))
+					<ul>
+						@foreach($query as $query_res)
+							<li>{{ $query_res->{$options->label} }}</li>
+						@endforeach
+					</ul>
+					
+				@else
+					<p>{{__('voyager::generic.no_results')}}</p>
+				@endif
 
-            @if(isset($view) && ($view == 'browse' || $view == 'read'))
+			@endif
 
-                @php
-                    $relationshipData = (isset($data)) ? $data : $dataTypeContent;
-                    $model = app($options->model);
-                    $selected_values = $model::where($options->column, '=', $relationshipData->id)->pluck($options->label)->all();
-                @endphp
+		@elseif($options->type == 'belongsToMany')
 
-                @if($view == 'browse')
-                    @php
-                        $string_values = implode(", ", $selected_values);
-                        if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
-                    @endphp
-                    @if(empty($selected_values))
-                        <p>No results</p>
-                    @else
-                        <p>{{ $string_values }}</p>
-                    @endif
-                @else
-                    @if(empty($selected_values))
-                        <p>No results</p>
-                    @else
-                        <ul>
-                            @foreach($selected_values as $selected_value)
-                                <li>{{ $selected_value }}</li>
-                            @endforeach
-                        </ul>
-                    @endif
-                @endif
+			@if(isset($view) && ($view == 'browse' || $view == 'read'))
 
-            @else
+				@php
+					$relationshipData = (isset($data)) ? $data : $dataTypeContent;
+	            	$selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->pluck($options->label)->all() : array();
+	            @endphp
 
-                @php
-                    $model = app($options->model);
-                    $query = $model::where($options->column, '=', $dataTypeContent->id)->get();
-                @endphp
+	            @if($view == 'browse')
+	            	@php
+	            		$string_values = implode(", ", $selected_values); 
+	            		if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; } 
+	            	@endphp
+	            	@if(empty($selected_values))
+		            	<p>{{__('voyager::generic.no_results')}}</p>
+		            @else
+	            		<p>{{ $string_values }}</p>
+	            	@endif
+	            @else
+	            	@if(empty($selected_values))
+		            	<p>{{__('voyager::generic.no_results')}}</p>
+		            @else
+		            	<ul>
+			            	@foreach($selected_values as $selected_value)
+			            		<li>{{ $selected_value }}</li>
+			            	@endforeach
+			            </ul>
+			        @endif
+	            @endif
 
-                @if(isset($query))
-                    <ul>
-                        @foreach($query as $query_res)
-                            <li>{{ $query_res->{$options->label} }}</li>
-                        @endforeach
-                    </ul>
+			@else
+				<select
+					class="form-control select2ajax @if(isset($options->taggable) && $options->taggable == 'on') select2-taggable @else select2 @endif" 
+					name="{{ $relationshipField }}[]" multiple
+					data-model="{{ $options->model }}" data-key="{{ $options->key }}" data-label="{{ $options->label }}" data-perpage="20"
+					@if(isset($options->taggable) && $options->taggable == 'on')
+						data-route="{{ route('voyager.'.str_slug($options->table).'.store') }}"
+						data-label="{{$options->label}}"
+						data-error-message="{{__('voyager::bread.error_tagging')}}"
+					@endif
+				>
+					
+						@php 
+							// Loads the pre-selected values (key/value pairs)
+							$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->table.'.'.$options->label, $options->table.'.'.$options->key)->all() : array();
+							Log::debug($selected_values);
+						@endphp
+						
+						@if($row->required === 0)
+							<option value="">{{__('voyager::generic.none')}}</option>
+						@endif
 
-                @else
-                    <p>No results</p>
-                @endif
+			            @foreach($selected_values as $key => $value)
+			                <option value="{{ $key }}" selected="selected">{{ $value }}</option>
+			            @endforeach
 
-            @endif
+				</select>
 
-        @elseif($options->type == 'belongsToMany')
+			@endif
 
-            @if(isset($view) && ($view == 'browse' || $view == 'read'))
+		@endif
 
-                @php
-                    $relationshipData = (isset($data)) ? $data : $dataTypeContent;
-                    $selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table)->pluck($options->label)->all() : array();
-                @endphp
+	@else
 
-                @if($view == 'browse')
-                    @php
-                        $string_values = implode(", ", $selected_values);
-                        if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
-                    @endphp
-                    @if(empty($selected_values))
-                        <p>No results</p>
-                    @else
-                        <p>{{ $string_values }}</p>
-                    @endif
-                @else
-                    @if(empty($selected_values))
-                        <p>No results</p>
-                    @else
-                        <ul>
-                            @foreach($selected_values as $selected_value)
-                                <li>{{ $selected_value }}</li>
-                            @endforeach
-                        </ul>
-                    @endif
-                @endif
+		cannot make relationship because {{ $options->model }} does not exist.
 
-            @else
-                <select
-                    class="form-control @if(isset($options->taggable) && $options->taggable == 'on') select2-taggable @else select2 @endif"
-                    name="{{ $relationshipField }}[]" multiple
-                    @if(isset($options->taggable) && $options->taggable == 'on')
-                        data-route="{{ route('voyager.'.str_slug($options->table).'.store') }}"
-                        data-label="{{$options->label}}"
-                        data-error-message="{{__('voyager::bread.error_tagging')}}"
-                    @endif
-                >
-
-                        @php
-                            $selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->table.'.'.$options->key)->all() : array();
-                            $relationshipOptions = app($options->model)->all();
-                        @endphp
-
-                        @if($row->required === 0)
-                            <option value="">{{__('voyager::generic.none')}}</option>
-                        @endif
-
-                        @foreach($relationshipOptions as $relationshipOption)
-                            <option value="{{ $relationshipOption->{$options->key} }}" @if(in_array($relationshipOption->{$options->key}, $selected_values)){{ 'selected="selected"' }}@endif>{{ $relationshipOption->{$options->label} }}</option>
-                        @endforeach
-
-                </select>
-
-            @endif
-
-        @endif
-
-    @else
-
-        cannot make relationship because {{ $options->model }} does not exist.
-
-    @endif
+	@endif
 
 @endif
+
+@section('javascript')
+<script>
+$(document).ready(function () {
+	$('.select2ajax').select2({
+		ajax: {
+			url: '{{route("select2ajax")}}',
+			dataType: 'json',
+			delay: 500,
+			data: function (params) {
+				var query = {
+					search: params.term,
+					page: params.page || 1,
+					model: $(this).data('model'),
+					key: $(this).data('key'),
+					label: $(this).data('label'),
+					perpage: $(this).data('perpage'),
+				}
+				return query;
+			}
+		}
+	});
+});
+</script>
+@endsection

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -159,7 +159,6 @@
 						@php 
 							// Loads the pre-selected values (key/value pairs)
 							$selected_values = isset($dataTypeContent) ? $dataTypeContent->belongsToMany($options->model, $options->pivot_table)->pluck($options->table.'.'.$options->label, $options->table.'.'.$options->key)->all() : array();
-							Log::debug($selected_values);
 						@endphp
 						
 						@if($row->required === 0)

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -37,7 +37,7 @@
 						<option value="">{{__('voyager::generic.none')}}</option>
 					@endif
 					
-					@if($selected_value)
+					@if(count($selected_value) > 0)
 						<option value="{{ $dataTypeContent->{$options->column} }}" selected="selected">{{ $selected_value[$dataTypeContent->{$options->column}] }}</option>
 					@endif
 				</select>

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -189,7 +189,7 @@
 $(document).ready(function () {
 	$('.select2ajax').select2({
 		ajax: {
-			url: '{{route("select2ajax")}}',
+			url: '{{route("voyager.select2ajax")}}',
 			dataType: 'json',
 			delay: 500,
 			data: function (params) {

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -128,7 +128,7 @@ Route::group(['as' => 'voyager.'], function () {
             Route::get('/', ['uses' => $namespacePrefix.'VoyagerCompassController@index',  'as' => 'index']);
             Route::post('/', ['uses' => $namespacePrefix.'VoyagerCompassController@index',  'as' => 'post']);
         });
-        
+
         // Select2 Ajax Route
         Route::get('select2ajax', ['uses' => $namespacePrefix.'VoyagerBaseController@select2ajax',  'as' => 'select2ajax']);
 

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -130,7 +130,7 @@ Route::group(['as' => 'voyager.'], function () {
         });
         
         // Select2 Ajax Route
-        Route::get('select2ajax', ['uses' => $namespacePrefix.'VoyagerBreadController@select2ajax',  'as' => 'select2ajax']);
+        Route::get('select2ajax', ['uses' => $namespacePrefix.'VoyagerBaseController@select2ajax',  'as' => 'select2ajax']);
 
         event(new RoutingAdminAfter());
     });

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -128,6 +128,9 @@ Route::group(['as' => 'voyager.'], function () {
             Route::get('/', ['uses' => $namespacePrefix.'VoyagerCompassController@index',  'as' => 'index']);
             Route::post('/', ['uses' => $namespacePrefix.'VoyagerCompassController@index',  'as' => 'post']);
         });
+        
+        // Select2 Ajax Route
+        Route::get('select2ajax', ['uses' => $namespacePrefix.'VoyagerBreadController@select2ajax',  'as' => 'select2ajax']);
 
         event(new RoutingAdminAfter());
     });

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -529,7 +529,7 @@ class VoyagerBaseController extends Controller
 
         // Creates JSON
         $json_results = [];
-        $json_pagination = (object)['more' => true];
+        $json_pagination = (object) ['more' => true];
 
         foreach ($results as $result_key => $result_value) {
             $json_results[] = ['id' => $result_key, 'text' => $result_value];
@@ -540,7 +540,7 @@ class VoyagerBaseController extends Controller
             $json_pagination->more = false;
         }            
 
-        $json = (object)['results' => $json_results, 'pagination' => $json_pagination];
+        $json = (object) ['results' => $json_results, 'pagination' => $json_pagination];
 
         return response()->json($json);
     }

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -508,12 +508,12 @@ class VoyagerBaseController extends Controller
     // Loads data with pagination and infinite scrolling for relationship formfields
     public function select2ajax(Request $request)
     {
-        $search = $request["search"];
-        $page = $request["page"];
-        $model = str_replace("\\\\", "\\", $request["model"]); // removes double backslashes
-        $key = $request["key"];
-        $label = $request["label"];
-        $perpage = $request["perpage"];
+        $search = $request['search'];
+        $page = $request['page'];
+        $model = str_replace('\\\\', '\\', $request['model']); // removes double backslashes
+        $key = $request['key'];
+        $label = $request['label'];
+        $perpage = $request['perpage'];
         $offset = (intval($page) - 1) * intval($perpage);
 
         // Builds the query
@@ -521,23 +521,23 @@ class VoyagerBaseController extends Controller
 
         // Adds search filter
         if(!empty($search))
-            $query = $query->where($label, "like", "%$search%");
+            $query = $query->where($label, 'like', '%$search%');
 
         // Loads data
         $results = $query->pluck($label, $key);
 
         // Creates JSON
         $json_results = [];
-        $json_pagination = (object)["more" => true];
+        $json_pagination = (object)['more' => true];
 
         foreach($results as $result_key => $result_value)
-            $json_results[] = ["id" => $result_key, "text" => $result_value];
+            $json_results[] = ['id' => $result_key, 'text' => $result_value];
 
         // Check if it's the last chunk of data
         if(count($results) < $perpage)
             $json_pagination->more = false;
 
-        $json = (object)["results" => $json_results, "pagination" => $json_pagination];
+        $json = (object)['results' => $json_results, 'pagination' => $json_pagination];
 
         return response()->json($json);
     }

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -520,7 +520,7 @@ class VoyagerBaseController extends Controller
         $query = app($model)->limit($perpage)->offset($offset);
 
         // Adds search filter
-        if(!empty($search))
+        if (!empty($search))
             $query = $query->where($label, 'like', '%$search%');
 
         // Loads data
@@ -530,11 +530,11 @@ class VoyagerBaseController extends Controller
         $json_results = [];
         $json_pagination = (object)['more' => true];
 
-        foreach($results as $result_key => $result_value)
+        foreach ($results as $result_key => $result_value)
             $json_results[] = ['id' => $result_key, 'text' => $result_value];
 
         // Check if it's the last chunk of data
-        if(count($results) < $perpage)
+        if (count($results) < $perpage)
             $json_pagination->more = false;
 
         $json = (object)['results' => $json_results, 'pagination' => $json_pagination];

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -520,8 +520,9 @@ class VoyagerBaseController extends Controller
         $query = app($model)->limit($perpage)->offset($offset);
 
         // Adds search filter
-        if (!empty($search))
+        if (!empty($search)) {
             $query = $query->where($label, 'like', '%$search%');
+        }            
 
         // Loads data
         $results = $query->pluck($label, $key);
@@ -530,12 +531,14 @@ class VoyagerBaseController extends Controller
         $json_results = [];
         $json_pagination = (object)['more' => true];
 
-        foreach ($results as $result_key => $result_value)
+        foreach ($results as $result_key => $result_value) {
             $json_results[] = ['id' => $result_key, 'text' => $result_value];
+        }            
 
         // Check if it's the last chunk of data
-        if (count($results) < $perpage)
+        if (count($results) < $perpage) {
             $json_pagination->more = false;
+        }            
 
         $json = (object)['results' => $json_results, 'pagination' => $json_pagination];
 

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -504,7 +504,7 @@ class VoyagerBaseController extends Controller
             $i->save();
         }
     }
-    
+
     // Loads data with pagination and infinite scrolling for relationship formfields
     public function select2ajax(Request $request)
     {
@@ -522,7 +522,7 @@ class VoyagerBaseController extends Controller
         // Adds search filter
         if (!empty($search)) {
             $query = $query->where($label, 'like', '%$search%');
-        }            
+        }
 
         // Loads data
         $results = $query->pluck($label, $key);
@@ -533,12 +533,12 @@ class VoyagerBaseController extends Controller
 
         foreach ($results as $result_key => $result_value) {
             $json_results[] = ['id' => $result_key, 'text' => $result_value];
-        }            
+        }
 
         // Check if it's the last chunk of data
         if (count($results) < $perpage) {
             $json_pagination->more = false;
-        }            
+        }
 
         $json = (object) ['results' => $json_results, 'pagination' => $json_pagination];
 

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -504,4 +504,41 @@ class VoyagerBaseController extends Controller
             $i->save();
         }
     }
+    
+    // Loads data with pagination and infinite scrolling for relationship formfields
+    public function select2ajax(Request $request)
+    {
+        $search = $request["search"];
+        $page = $request["page"];
+        $model = str_replace("\\\\", "\\", $request["model"]); // removes double backslashes
+        $key = $request["key"];
+        $label = $request["label"];
+        $perpage = $request["perpage"];
+        $offset = (intval($page) - 1) * intval($perpage);
+
+        // Builds the query
+        $query = app($model)->limit($perpage)->offset($offset);
+
+        // Adds search filter
+        if(!empty($search))
+            $query = $query->where($label, "like", "%$search%");
+
+        // Loads data
+        $results = $query->pluck($label, $key);
+
+        // Creates JSON
+        $json_results = [];
+        $json_pagination = (object)["more" => true];
+
+        foreach($results as $result_key => $result_value)
+            $json_results[] = ["id" => $result_key, "text" => $result_value];
+
+        // Check if it's the last chunk of data
+        if(count($results) < $perpage)
+            $json_pagination->more = false;
+
+        $json = (object)["results" => $json_results, "pagination" => $json_pagination];
+
+        return response()->json($json);
+    }
 }


### PR DESCRIPTION
**Problem:** The current Relationship formfield loads all records from a BelongsTo or BelongsToMany relationship before showing the view. With some hundred records there is a bottleneck problem, with thousands of records it freezes the browser. 

**Solution:** This update uses Select2 Ajax remote loading feature with pagination and infinite scrolling. It loads 20 records at a time, it adds 20 more records for each scroll, it's searchable, it shows the preselected values, it works with belongsTo and belongsToMany relations, it works with multiple relationship formfields on the same view.

- I edited the main relationship.blade.php to add Ajax logic.
- I saved the action to load ajax data into the VoyagerBaseController, but maybe it should be saved into the Relationship Controller.
- I edited the voyager.php to add the ajax action route.