### PR TITLE
Database Test fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "illuminate/support": "~5.4.0|~5.5.0|~5.6.0",
         "intervention/image": "^2.4",
-        "doctrine/dbal": "2.7.*",
+        "doctrine/dbal": "~2.5.0|~2.6.0|~2.7.0",
         "larapack/doctrine-support": "~0.1.4",
         "arrilot/laravel-widgets": "^3.7",
         "league/flysystem": "~1.0.41",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "illuminate/support": "~5.4.0|~5.5.0|~5.6.0",
         "intervention/image": "^2.4",
-        "doctrine/dbal": "^2.5",
+        "doctrine/dbal": "2.7.*",
         "larapack/doctrine-support": "~0.1.4",
         "arrilot/laravel-widgets": "^3.7",
         "league/flysystem": "~1.0.41",

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -235,8 +235,8 @@ class DatabaseTest extends TestCase
 
         $this->assertTrue($dbTable->hasIndex('primary'));
 
-        $dbTable->addIndex(['id'], 'id_index');
         $dbTable->dropPrimaryKey();
+        $dbTable->addIndex(['id'], 'id_index');
 
         $this->assertFalse($dbTable->hasIndex('primary'));
         $this->assertTrue($dbTable->hasIndex('id_index'));

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -235,10 +235,10 @@ class DatabaseTest extends TestCase
 
         $this->assertTrue($dbTable->hasIndex('primary'));
 
-        $dbTable->dropPrimaryKey();
         $dbTable->addIndex(['id'], 'id_index');
 
         $dbTable = $this->update_table($dbTable->toArray());
+        $dbTable->dropPrimaryKey();
 
         $this->assertFalse($dbTable->hasIndex('primary'));
         $this->assertTrue($dbTable->hasIndex('id_index'));

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -236,12 +236,10 @@ class DatabaseTest extends TestCase
         $this->assertTrue($dbTable->hasIndex('primary'));
 
         $dbTable->addIndex(['id'], 'id_index');
-        $this->assertTrue($dbTable->hasIndex('id_index'));
-
-        $dbTable = $this->update_table($dbTable->toArray());
         $dbTable->dropPrimaryKey();
 
         $this->assertFalse($dbTable->hasIndex('primary'));
+        $this->assertTrue($dbTable->hasIndex('id_index'));
     }
 
     protected function update_table(array $table)

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -236,12 +236,12 @@ class DatabaseTest extends TestCase
         $this->assertTrue($dbTable->hasIndex('primary'));
 
         $dbTable->addIndex(['id'], 'id_index');
+        $this->assertTrue($dbTable->hasIndex('id_index'));
 
         $dbTable = $this->update_table($dbTable->toArray());
         $dbTable->dropPrimaryKey();
 
         $this->assertFalse($dbTable->hasIndex('primary'));
-        $this->assertTrue($dbTable->hasIndex('id_index'));
     }
 
     protected function update_table(array $table)

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -240,6 +240,8 @@ class DatabaseTest extends TestCase
 
         $this->assertFalse($dbTable->hasIndex('primary'));
         $this->assertTrue($dbTable->hasIndex('id_index'));
+
+        $dbTable = $this->update_table($dbTable->toArray());
     }
 
     protected function update_table(array $table)

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -238,10 +238,10 @@ class DatabaseTest extends TestCase
         $dbTable->dropPrimaryKey();
         $dbTable->addIndex(['id'], 'id_index');
 
+        $dbTable = $this->update_table($dbTable->toArray());
+
         $this->assertFalse($dbTable->hasIndex('primary'));
         $this->assertTrue($dbTable->hasIndex('id_index'));
-
-        $dbTable = $this->update_table($dbTable->toArray());
     }
 
     protected function update_table(array $table)


### PR DESCRIPTION
This fixes the `DatabaseTest` failing when using [DBAL >= 2.8.0](https://github.com/doctrine/dbal/releases/tag/v2.8.0).
I honestly dont know what they changed, but changing back to `DBAL 2.7.2` does not throw any errors.

What happens (and why it failed) is:

- The primary key was dropped
- The table-data is sended to Voyagers-UI and saved
- The primary-key is back (This is where the problem starts)
- `assertFalse()` fails

All I can say is that its *not* Voyagers fault as there was no commit at the time the tests started failing.

~The outcome/functionality of the `can_change_index()` test should still be the same.~