### PR TITLE
# Hidden ID Field Fix, Attempt Deux #

### DIFF
--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -16,9 +16,11 @@ trait BreadRelationshipParser
         foreach ($dataType->{$bread_type.'Rows'} as $key => $row) {
             if ($row->type == 'relationship') {
                 $options = json_decode($row->details);
-                $relationshipField = @$options->column;
-                $keyInCollection = key($dataType->{$bread_type.'Rows'}->where('field', '=', $relationshipField)->toArray());
-                array_push($forget_keys, $keyInCollection);
+                if ($options->type == 'belongsTo') {
+                    $relationshipField = @$options->column;
+                    $keyInCollection = key($dataType->{$bread_type . 'Rows'}->where('field', '=', $relationshipField)->toArray());
+                    array_push($forget_keys, $keyInCollection);
+                }
             }
         }
 

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -53,7 +53,9 @@ class VoyagerBaseController extends Controller
             $query = $model::select('*')->with($relationships);
 
             // If a column has a relationship associated with it, we do not want to show that field
-            $this->removeRelationshipField($dataType, 'browse');
+            // Commented-out as this hides the `id` field in all BREAD operations.
+            // TODO: Make a config var for this (and the other operations as well).
+//            $this->removeRelationshipField($dataType, 'browse');
 
             if ($search->value && $search->key && $search->filter) {
                 $search_filter = ($search->filter == 'equals') ? '=' : 'LIKE';
@@ -138,7 +140,9 @@ class VoyagerBaseController extends Controller
         $dataTypeContent = $this->resolveRelations($dataTypeContent, $dataType, true);
 
         // If a column has a relationship associated with it, we do not want to show that field
-        $this->removeRelationshipField($dataType, 'read');
+        // Commented-out as this hides the `id` field in all BREAD operations.
+        // TODO: Make a config var for this (and the other operations as well).
+//        $this->removeRelationshipField($dataType, 'read');
 
         // Check permission
         $this->authorize('read', $dataTypeContent);
@@ -185,7 +189,9 @@ class VoyagerBaseController extends Controller
         }
 
         // If a column has a relationship associated with it, we do not want to show that field
-        $this->removeRelationshipField($dataType, 'edit');
+        // Commented-out as this hides the `id` field in all BREAD operations.
+        // TODO: Make a config var for this (and the other operations as well).
+//        $this->removeRelationshipField($dataType, 'edit');
 
         // Check permission
         $this->authorize('edit', $dataTypeContent);
@@ -270,7 +276,9 @@ class VoyagerBaseController extends Controller
         }
 
         // If a column has a relationship associated with it, we do not want to show that field
-        $this->removeRelationshipField($dataType, 'add');
+        // Commented-out as this hides the `id` field in all BREAD operations.
+        // TODO: Make a config var for this (and the other operations as well).
+//        $this->removeRelationshipField($dataType, 'add');
 
         // Check if BREAD is Translatable
         $isModelTranslatable = is_bread_translatable($dataTypeContent);

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -53,9 +53,7 @@ class VoyagerBaseController extends Controller
             $query = $model::select('*')->with($relationships);
 
             // If a column has a relationship associated with it, we do not want to show that field
-            // Commented-out as this hides the `id` field in all BREAD operations.
-            // TODO: Make a config var for this (and the other operations as well).
-//            $this->removeRelationshipField($dataType, 'browse');
+            $this->removeRelationshipField($dataType, 'browse');
 
             if ($search->value && $search->key && $search->filter) {
                 $search_filter = ($search->filter == 'equals') ? '=' : 'LIKE';
@@ -140,9 +138,7 @@ class VoyagerBaseController extends Controller
         $dataTypeContent = $this->resolveRelations($dataTypeContent, $dataType, true);
 
         // If a column has a relationship associated with it, we do not want to show that field
-        // Commented-out as this hides the `id` field in all BREAD operations.
-        // TODO: Make a config var for this (and the other operations as well).
-//        $this->removeRelationshipField($dataType, 'read');
+        $this->removeRelationshipField($dataType, 'read');
 
         // Check permission
         $this->authorize('read', $dataTypeContent);
@@ -189,9 +185,7 @@ class VoyagerBaseController extends Controller
         }
 
         // If a column has a relationship associated with it, we do not want to show that field
-        // Commented-out as this hides the `id` field in all BREAD operations.
-        // TODO: Make a config var for this (and the other operations as well).
-//        $this->removeRelationshipField($dataType, 'edit');
+        $this->removeRelationshipField($dataType, 'edit');
 
         // Check permission
         $this->authorize('edit', $dataTypeContent);
@@ -276,9 +270,7 @@ class VoyagerBaseController extends Controller
         }
 
         // If a column has a relationship associated with it, we do not want to show that field
-        // Commented-out as this hides the `id` field in all BREAD operations.
-        // TODO: Make a config var for this (and the other operations as well).
-//        $this->removeRelationshipField($dataType, 'add');
+        $this->removeRelationshipField($dataType, 'add');
 
         // Check if BREAD is Translatable
         $isModelTranslatable = is_bread_translatable($dataTypeContent);


### PR DESCRIPTION
All credit for finding the cause goes to @MrCrayon. If I understand the underlying cause correctly, the default `id` field is being saved with a `belongsToMany` relationship, which makes it appear as though the `id` field is connected to it, when it shouldn't be. Thus, we stop it from making such a 'connection' by only saving the field if the relationship is a `belongsTo` relationship. Further details can be seen in #3456. This PR supersedes #3451.

* Restores the commented-out lines that were clearly not a part of the problem.
* Adds a check to see if a given relationship is `belongsTo` before hiding any fields associated with it.