### PR TITLE
Allow prefilling fields from URL parameters

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -260,10 +260,16 @@ class VoyagerBaseController extends Controller
 
         // Check permission
         $this->authorize('add', app($dataType->model_name));
-
-        $dataTypeContent = (strlen($dataType->model_name) != 0)
-                            ? new $dataType->model_name()
-                            : false;
+        
+        // Prefill fields
+        if ($request->has('prefill')) {
+            $prefillObject = unserialize(base64_decode($request->get('prefill')));
+            $dataTypeContent = $prefillObject;
+        } else {
+            $dataTypeContent = (strlen($dataType->model_name) != 0)
+                                ? new $dataType->model_name()
+                                : false;
+        }
 
         foreach ($dataType->addRows as $key => $row) {
             $details = json_decode($row->details);


### PR DESCRIPTION
This patch adds the ability of generating permalinks for creating bread items and prefilling any of their fields.

Example use scenario: we have two models "Post" and "Category" and we'd like to add action buttons in the "Category" browse view next to the "View", "Edit" and "Delete" buttons. Our buttons would read "Add Post" and "Add Draft" so the admin can instantly add a post inside the selected category without leaving the category browse view. With this patch applied, this could be achieved simply by giving the buttons the following links:

### Add Post:
```php
route('voyager.posts.create', ['prefill' => base64_encode(serialize((
    new \App\Post())->forceFill([
        'category_id' => $data->{$data->getKeyName()},
    ])
))])
```

### Add Draft:
```php
route('voyager.posts.create', ['prefill' => base64_encode(serialize((
    new \App\Post())->forceFill([
        'category_id' => $data->{$data->getKeyName()},
        'status' => 'draft',
    ])
))])
```

I was asked to do this for a client so I thought I'd share it with everyone else as well.

## Things that could be improved:
- I think the "base64_encode serialize" part looks ugly and would appreciate any effort at cleaning it up.
- I know this could throw unhandled errors if the prefill parameter had invalid b64 string or invalid serialized object but I didn't want to overcomplicate my patch. besides, this should only happen if the admin panel developer didn't test their implementation well.