### PR TITLE
 FixBug: Remove relationship field only with 'belongsTo' relations

### DIFF
--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -18,7 +18,7 @@ trait BreadRelationshipParser
                 $options = json_decode($row->details);
                 if ($options->type == 'belongsTo') {
                     $relationshipField = @$options->column;
-                    $keyInCollection = key($dataType->{$bread_type . 'Rows'}->where('field', '=', $relationshipField)->toArray());
+                    $keyInCollection = key($dataType->{$bread_type.'Rows'}->where('field', '=', $relationshipField)->toArray());
                     array_push($forget_keys, $keyInCollection);
                 }
             }

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -16,7 +16,7 @@ trait BreadRelationshipParser
         foreach ($dataType->{$bread_type.'Rows'} as $key => $row) {
             if ($row->type == 'relationship') {
                 $options = json_decode($row->details);
-                if ( $options->type == 'belongsTo' ) {
+                if ($options->type == 'belongsTo') {
                     $relationshipField = @$options->column;
                     $keyInCollection = key($dataType->{$bread_type . 'Rows'}->where('field', '=', $relationshipField)->toArray());
                     array_push($forget_keys, $keyInCollection);

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -16,9 +16,11 @@ trait BreadRelationshipParser
         foreach ($dataType->{$bread_type.'Rows'} as $key => $row) {
             if ($row->type == 'relationship') {
                 $options = json_decode($row->details);
-                $relationshipField = @$options->column;
-                $keyInCollection = key($dataType->{$bread_type.'Rows'}->where('field', '=', $relationshipField)->toArray());
-                array_push($forget_keys, $keyInCollection);
+                if ( $options->type == 'belongsTo' ) {
+                    $relationshipField = @$options->column;
+                    $keyInCollection = key($dataType->{$bread_type . 'Rows'}->where('field', '=', $relationshipField)->toArray());
+                    array_push($forget_keys, $keyInCollection);
+                }
             }
         }
 


### PR DESCRIPTION
**Issue:** Relationship field disappears when creating relationships

Related to #2441

It logically seems that among the supported relations : belongsTo, belongsToMany, hasMany, hasOne,
we only need to remove the key field when the relation is of type 'belongsTo'.