### PR TITLE
Select multiple throwing Invalid argument

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -115,7 +115,9 @@
                                                     @elseif(property_exists($options, 'options'))
                                                         @if (count(json_decode($data->{$row->field})) > 0)
                                                             @foreach(json_decode($data->{$row->field}) as $item)
-                                                             {{ $options->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                                                @if (@$options->options->{$item})
+                                                                    {{ $options->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                                                @endif
                                                             @endforeach
                                                         @else
                                                             {{ __('voyager::generic.none') }}

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -113,9 +113,13 @@
                                                         @endforeach
 
                                                     @elseif(property_exists($options, 'options'))
-                                                        @foreach($data->{$row->field} as $item)
-                                                         {{ $options->options->{$item} . (!$loop->last ? ', ' : '') }}
-                                                        @endforeach
+                                                        @if (count(json_decode($data->{$row->field})) > 0)
+                                                            @foreach(json_decode($data->{$row->field}) as $item)
+                                                             {{ $options->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                                            @endforeach
+                                                        @else
+                                                            {{ __('voyager::generic.none') }}
+                                                        @endif
                                                     @endif
 
                                                 @elseif($row->type == 'select_dropdown' && property_exists($options, 'options'))

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -80,9 +80,13 @@
                                     @endforeach
 
                                 @elseif(property_exists($rowDetails, 'options'))
-                                    @foreach(json_decode($dataTypeContent->{$row->field}) as $item)
-                                        {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
-                                    @endforeach
+                                    @if (count(json_decode($dataTypeContent->{$row->field})) > 0)
+                                        @foreach(json_decode($dataTypeContent->{$row->field}) as $item)
+                                            {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                        @endforeach
+                                    @else
+                                        {{ __('voyager::generic.none') }}
+                                    @endif
                                 @endif
                             @elseif($row->type == 'date' || $row->type == 'timestamp')
                                 {{ $rowDetails && property_exists($rowDetails, 'format') ? \Carbon\Carbon::parse($dataTypeContent->{$row->field})->formatLocalized($rowDetails->format) : $dataTypeContent->{$row->field} }}

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -82,7 +82,9 @@
                                 @elseif(property_exists($rowDetails, 'options'))
                                     @if (count(json_decode($dataTypeContent->{$row->field})) > 0)
                                         @foreach(json_decode($dataTypeContent->{$row->field}) as $item)
-                                            {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                            @if (@$rowDetails->options->{$item})
+                                                {{ $rowDetails->options->{$item} . (!$loop->last ? ', ' : '') }}
+                                            @endif
                                         @endforeach
                                     @else
                                         {{ __('voyager::generic.none') }}


### PR DESCRIPTION
The browse-view didn't `json_decode` the data from the DB, leading to a
`Invalid argument supplied for foreach() (View: vendor/tcg/voyager/resources/views/bread/browse.blade.php)`

Because it was trying to execute (for example)
```
foreach ('["1","3"]' as $item) {  }
```
This PR also fixes the read-view when the value is `null`
```
foreach (json_decode(NULL) as $item) {  }
```

Fixes https://github.com/the-control-group/voyager/issues/3388