### PR TITLE
Allow setting field descriptions via a translation file

### DIFF
--- a/src/FormFields/After/DescriptionHandler.php
+++ b/src/FormFields/After/DescriptionHandler.php
@@ -8,6 +8,11 @@ class DescriptionHandler extends AbstractHandler
 
     public function visible($row, $dataType, $dataTypeContent, $options)
     {
+        $trans = 'voyager.help.'.$dataType->name.'.'.$row->field;
+        if(__($trans) !== $trans) {
+            return true;
+        }
+
         if (!isset($options->description)) {
             return false;
         }
@@ -17,10 +22,17 @@ class DescriptionHandler extends AbstractHandler
 
     public function createContent($row, $dataType, $dataTypeContent, $options)
     {
+        if(isset($options->description)) {
+            $helpText = $options->description;
+        } else {
+            $helpText = __('voyager.help.'.$dataType->name.'.'.$row->field);
+        }
+
         return '<span class="glyphicon glyphicon-question-sign"
                                         aria-hidden="true"
                                         data-toggle="tooltip"
-                                        data-placement="right"
-                                        title="'.$options->description.'"></span>';
+                                        data-placement="auto"
+                                        data-html="true"
+                                        title="'.$helpText.'"></span>';
     }
 }

--- a/src/FormFields/After/DescriptionHandler.php
+++ b/src/FormFields/After/DescriptionHandler.php
@@ -9,7 +9,7 @@ class DescriptionHandler extends AbstractHandler
     public function visible($row, $dataType, $dataTypeContent, $options)
     {
         $trans = 'voyager.help.'.$dataType->name.'.'.$row->field;
-        if(__($trans) !== $trans) {
+        if (__($trans) !== $trans) {
             return true;
         }
 
@@ -22,7 +22,7 @@ class DescriptionHandler extends AbstractHandler
 
     public function createContent($row, $dataType, $dataTypeContent, $options)
     {
-        if(isset($options->description)) {
+        if (isset($options->description)) {
             $helpText = $options->description;
         } else {
             $helpText = __('voyager.help.'.$dataType->name.'.'.$row->field);


### PR DESCRIPTION
In order to simplify updating field descriptions I added a few lines of code to the DescriptionHandler class. Default behavior is not changed, so if a DataRow has $details->description set, that description will be displayed. However, if a translation `voyager.help.{$dataType->name}.{$row->field}` exists, that will be used.

So suppose we have a DataType `posts` which has one DataRow `title`. The DescriptionHandler as it is now will just check whether `DataRow->options->description` exists. If it doesn't exist, the description isn't visible. The updated version does an additional check (only if options->description isn't set) - it looks for the translation voyager.help.posts.title and uses that instead, if it exists.