### PR TITLE
Proposed fix for multiple image field quality setting

### DIFF
--- a/src/Http/Controllers/ContentTypes/MultipleImage.php
+++ b/src/Http/Controllers/ContentTypes/MultipleImage.php
@@ -37,7 +37,7 @@ class MultipleImage extends BaseType
                 $resize_height = $image->height();
             }
 
-            $resize_quality = isset($options->quality) ? intval($this->options->quality) : 75;
+            $resize_quality = isset($this->options->quality) ? intval($this->options->quality) : 75;
 
             $filename = Str::random(20);
             $path = $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;


### PR DESCRIPTION
This is a duplicate PR of https://github.com/the-control-group/voyager/pull/3507 on the 1.1 branch as requested.

The multiple image content type class ignores user defined quality settings.

The class does an isset() check on the $options variable, which is not defined thus always returns false. As a result the $resize_quality variable is set to it's default of 75%.

This PR fixes the conditional check.