### PR TITLE
Fixed a permissions issue with deleting a menu item

### DIFF
--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -22,7 +22,7 @@ class VoyagerMenuController extends Controller
     {
         $item = Voyager::model('MenuItem')->findOrFail($id);
 
-        $this->authorize('delete', $item->menu);
+        $this->authorize('delete', $item);
 
         $item->deleteAttributeTranslation('title');
 


### PR DESCRIPTION
I have a user with the following permissions (not Delete Menus):
- Browse Menus
- Read Menus
- Edit Menus
- Add Menus

If I try to delete a menu item, I get the "This action is unauthorized." error message. I shouldn't need the permission "Delete menus" to delete a menu item.