### PR TITLE
Fix BREAD file type bug while delete

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -401,8 +401,10 @@ class VoyagerBaseController extends Controller
 
         // Delete Files
         foreach ($dataType->deleteRows->where('type', 'file') as $row) {
-            foreach (json_decode($data->{$row->field}) as $file) {
-                $this->deleteFileIfExists($file->download_link);
+            if (isset($data->{$row->field})) {
+                foreach (json_decode($data->{$row->field}) as $file) {
+                    $this->deleteFileIfExists($file->download_link);
+                }
             }
         }
     }


### PR DESCRIPTION
fix #1855 

The BREAD file type exist a bug that if it be set NULL，when delete it，it will throw
```
ErrorException (E_WARNING)
Invalid argument supplied for foreach()
```
because there is not check the variable