### PR TITLE
Fix issue with multiple BREADs using the same table

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -54,7 +54,10 @@ class VoyagerBreadController extends Controller
         $dataType = Voyager::model('DataType')->whereName($table)->first();
 
         $data = $this->prepopulateBreadInfo($table);
-        $data['fieldOptions'] = SchemaManager::describeTable(app($dataType->model_name)->getTable());
+        $data['fieldOptions'] = SchemaManager::describeTable((strlen($dataType->model_name) != 0)
+            ? app($dataType->model_name)->getTable()
+            : $table
+        );
 
         return Voyager::view('voyager::tools.bread.edit-add', $data);
     }
@@ -117,7 +120,10 @@ class VoyagerBreadController extends Controller
 
         $dataType = Voyager::model('DataType')->whereName($table)->first();
 
-        $fieldOptions = SchemaManager::describeTable(app($dataType->model_name)->getTable());
+        $fieldOptions = SchemaManager::describeTable((strlen($dataType->model_name) != 0)
+            ? app($dataType->model_name)->getTable()
+            : $dataType->name
+        );
 
         $isModelTranslatable = is_bread_translatable($dataType);
         $tables = SchemaManager::listTableNames();

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -51,8 +51,10 @@ class VoyagerBreadController extends Controller
     {
         Voyager::canOrFail('browse_bread');
 
+        $dataType = Voyager::model('DataType')->whereName($table)->first();
+
         $data = $this->prepopulateBreadInfo($table);
-        $data['fieldOptions'] = SchemaManager::describeTable($table);
+        $data['fieldOptions'] = SchemaManager::describeTable(app($dataType->model_name)->getTable());
 
         return Voyager::view('voyager::tools.bread.edit-add', $data);
     }
@@ -115,7 +117,7 @@ class VoyagerBreadController extends Controller
 
         $dataType = Voyager::model('DataType')->whereName($table)->first();
 
-        $fieldOptions = SchemaManager::describeTable($dataType->name);
+        $fieldOptions = SchemaManager::describeTable(app($dataType->model_name)->getTable());
 
         $isModelTranslatable = is_bread_translatable($dataType);
         $tables = SchemaManager::listTableNames();

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -94,7 +94,7 @@ class DataType extends Model
             }
 
             if ($this->fill($requestData)->save()) {
-                $fields = $this->fields(array_get($requestData, 'name'));
+                $fields = $this->fields(app($this->model_name)->getTable());
 
                 $requestData = $this->getRelationships($requestData, $fields);
 

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -94,7 +94,10 @@ class DataType extends Model
             }
 
             if ($this->fill($requestData)->save()) {
-                $fields = $this->fields(app($this->model_name)->getTable());
+                $fields = $this->fields((strlen($this->model_name) != 0)
+                    ? app($this->model_name)->getTable()
+                    : array_get($requestData, 'name')
+                );
 
                 $requestData = $this->getRelationships($requestData, $fields);
 
@@ -199,7 +202,10 @@ class DataType extends Model
         // Get ordered BREAD fields
         $orderedFields = $this->rows()->pluck('field')->toArray();
 
-        $_fieldOptions = SchemaManager::describeTable(app($this->model_name)->getTable())->toArray();
+        $_fieldOptions = SchemaManager::describeTable((strlen($this->model_name) != 0)
+            ? app($this->model_name)->getTable()
+            : $this->name
+        )->toArray();
 
         $fieldOptions = [];
         $f_size = count($orderedFields);

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -196,12 +196,10 @@ class DataType extends Model
 
     public function fieldOptions()
     {
-        $table = $this->name;
-
         // Get ordered BREAD fields
         $orderedFields = $this->rows()->pluck('field')->toArray();
 
-        $_fieldOptions = SchemaManager::describeTable($table)->toArray();
+        $_fieldOptions = SchemaManager::describeTable(app($this->model_name)->getTable())->toArray();
 
         $fieldOptions = [];
         $f_size = count($orderedFields);


### PR DESCRIPTION
When multiple data_types use the same table (via same or different models), BREAD editor wasn't saving the fields.