### PR TITLE
Use actual PK instead of assuming id.

### DIFF
--- a/resources/views/formfields/multiple_images.blade.php
+++ b/resources/views/formfields/multiple_images.blade.php
@@ -4,7 +4,7 @@
     @if($images != null)
         @foreach($images as $image)
             <div class="img_settings_container" data-field-name="{{ $row->field }}" style="float:left;padding-right:15px;">
-                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->id }}" style="max-width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:5px;">
+                <img src="{{ Voyager::image( $image ) }}" data-image="{{ $image }}" data-id="{{ $dataTypeContent->getKey() }}" style="max-width:200px; height:auto; clear:both; display:block; padding:2px; border:1px solid #ddd; margin-bottom:5px;">
                 <a href="#" class="voyager-x remove-multi-image"></a>
             </div>
         @endforeach


### PR DESCRIPTION
Multiple images removal is not working when using a primary key != "id" for the corresponding table. The `data-id` attribute for the images doesn't get populated and the ajax request returns a Bad Request error.