### PR TITLE
DataRow details default to {}

### DIFF
--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -298,7 +298,13 @@
                                         <div class="alert alert-danger validation-error">
                                             {{ __('voyager::json.invalid') }}
                                         </div>
-                                        <textarea id="json-input-{{ json_encode($data['field']) }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">@if(isset($dataRow->details)){{  json_encode($dataRow->details) }}@endif</textarea>
+                                        <textarea id="json-input-{{ json_encode($data['field']) }}" class="resizable-editor" data-editor="json" name="field_details_{{ $data['field'] }}">
+                                            @if(isset($dataRow->details))
+                                                {{ json_encode($dataRow->details) }}
+                                            @else
+                                                {}
+                                            @endif
+                                        </textarea>
                                     </div>
                                 </div>
 


### PR DESCRIPTION
When the data-row details field is empty it will store `null` as a string in the database.
Because of this, this condition is true:
https://github.com/the-control-group/voyager/blob/f48152acf799422bbe6b1cdb53a5353d61679389/src/Models/DataRow.php#L66
And executes `json_decode('null')`
 which will return `NULL`

Fixes https://github.com/the-control-group/voyager/issues/3654