### PR TITLE
fix for relationship template multibyte text substr issue

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -75,7 +75,7 @@
                 @if($view == 'browse')
                     @php
                         $string_values = implode(", ", $selected_values);
-                        if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
+                        if(mb_strlen($string_values) > 25){ $string_values = mb_substr($string_values, 0, 25) . '...'; }
                     @endphp
                     @if(empty($selected_values))
                         <p>No results</p>
@@ -128,7 +128,7 @@
                 @if($view == 'browse')
                     @php
                         $string_values = implode(", ", $selected_values);
-                        if(strlen($string_values) > 25){ $string_values = substr($string_values, 0, 25) . '...'; }
+                        if(mb_strlen($string_values) > 25){ $string_values = mb_substr($string_values, 0, 25) . '...'; }
                     @endphp
                     @if(empty($selected_values))
                         <p>No results</p>


### PR DESCRIPTION
For some long multibyte strings string data in table with relation columns is broken
Is was mentioned before in https://github.com/the-control-group/voyager/pull/2330
