### PR TITLE
First parameter must either be an object or the name of an existing c…

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -135,7 +135,11 @@
                                                 @elseif($row->type == 'select_dropdown' && $data->{$row->field . '_page_slug'})
                                                     <a href="{{ $data->{$row->field . '_page_slug'} }}">{{ $data->{$row->field} }}</a>
                                                 @elseif($row->type == 'date' || $row->type == 'timestamp')
+                                                    @if(!is_null($row->details))
                                                     {{ property_exists($row->details, 'format') ? \Carbon\Carbon::parse($data->{$row->field})->formatLocalized($row->details->format) : $data->{$row->field} }}
+                                                    @else
+                                                    {{ $data->{$row->field} }}
+                                                    @endif
                                                 @elseif($row->type == 'checkbox')
                                                     @if(property_exists($row->details, 'on') && property_exists($row->details, 'off'))
                                                         @if($data->{$row->field})


### PR DESCRIPTION
…lass

First parameter must either be an object or the name of an existing class issue arises when in create timestamp field in any entity. Id we do not specify any details options in bread, it stores in db null, so at the time of browse, it gives error.
So this is my workaround.