### PR TITLE
Update DataRow.php

### DIFF
--- a/src/Models/DataRow.php
+++ b/src/Models/DataRow.php
@@ -58,7 +58,7 @@ class DataRow extends Model
 
     public function setDetailsAttribute($value)
     {
-        $this->attributes['details'] = json_encode($value);
+        $this->attributes['details'] = is_object(@json_decode($value)) ? $value : json_encode($value);
     }
 
     public function getDetailsAttribute($value)


### PR DESCRIPTION
Adds a fix for saving relations on bread

because of the $value could be already a valid JSON there is NO need to encode it again. it causes an error when trying to decode it back to an object! 