### PR TITLE
Prevent MySQL error about foreign keys after running PHPUnit or Laravel Dusk tests

### DIFF
--- a/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -28,7 +28,7 @@ class AddUserRoleRelationship extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->dropForeign(['role_id']);
-            $table->integer('role_id')->change();
+            $table->unsignedInteger('role_id')->change();
         });
     }
 }


### PR DESCRIPTION
After running PHPUnit test or Laravel Dusk test, a MySQL error is thrown when rollback the migrations. By refactoring the down method a bit, so it's compatible with the up method (unsignedInteger vs integer), I were able to tackle this MySQL error.