### PR TITLE
Remove required attribute from Richtextbox

### DIFF
--- a/resources/views/formfields/rich_text_box.blade.php
+++ b/resources/views/formfields/rich_text_box.blade.php
@@ -1,4 +1,4 @@
-<textarea @if($row->required == 1) required @endif class="form-control richTextBox" name="{{ $row->field }}" id="richtext{{ $row->field }}">
+<textarea class="form-control richTextBox" name="{{ $row->field }}" id="richtext{{ $row->field }}">
     @if(isset($dataTypeContent->{$row->field}))
         {{ old($row->field, $dataTypeContent->{$row->field}) }}
     @else


### PR DESCRIPTION
Gets rid of `An invalid form control with name='...' is not focusable` errors
More information can be found in https://github.com/the-control-group/voyager/issues/3642 and https://github.com/the-control-group/voyager/issues/3209

Tested in Chrome 71 and works perfectly fine.

Fixes https://github.com/the-control-group/voyager/issues/3209 and fixes https://github.com/the-control-group/voyager/issues/3642 