### PR TITLE
Update migration, invalid rollback command

### DIFF
--- a/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -28,7 +28,7 @@ class AddUserRoleRelationship extends Migration
     {
         Schema::table('users', function (Blueprint $table) {
             $table->dropForeign(['role_id']);
-            $table->integer('role_id')->change();
+            $table->dropIfExists('role_id');
         });
     }
 }


### PR DESCRIPTION
`2017_11_26_013050_add_user_role_relationship.php`

Line 31 was:\
`$table->integer('role_id')->change();`
Should be:
`$table->dropIfExists('role_id');`