### PR TITLE
Fix media manager "Forbidden" error

### DIFF
--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -258,7 +258,7 @@
                     <!-- End Move File Modal -->
 
                     <!-- Image Modal -->
-                    <div class="modal fade" id="imagemodal">
+                    <div class="modal fade" id="imagemodal" v-if="selected_file.type != 'folder'">
                         <div class="modal-dialog">
                             <div class="modal-content">
                                 <div class="modal-header">

--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -258,7 +258,7 @@
                     <!-- End Move File Modal -->
 
                     <!-- Image Modal -->
-                    <div class="modal fade" id="imagemodal" v-if="selected_file.type != 'folder'">
+                    <div class="modal fade" id="imagemodal" v-if="selectedFileIs('image')">
                         <div class="modal-dialog">
                             <div class="modal-content">
                                 <div class="modal-header">


### PR DESCRIPTION
The MediaManager was throwing a JS-error when selecting a folder.
Thats because the image-modal (double-click **any** file) loads the currently selected file into an image-tag (no matter the type).
Fixes #3804