### PR TITLE
Mediamanager video/audio previews not loading

### DIFF
--- a/resources/assets/js/media.js
+++ b/resources/assets/js/media.js
@@ -28,12 +28,23 @@ module.exports = function(){
 					var month = "0" + (date.getMonth() + 1);
 					var minutes = "0" + date.getMinutes();
 					var seconds = "0" + date.getSeconds();
-					
+
 					var dateForamted = date.getFullYear() + '-' + month.substr(-2) + '-' + date.getDate() + ' ' + date.getHours() + ':' + minutes.substr(-2) + ':' + seconds.substr(-2);
-					
+
 					return dateForamted;
 				}
-			}
+			},
+            watch: {
+                selected_file: function (val) {
+                    this.$nextTick(() => {
+                        if (this.selectedFileIs('audio')) {
+                            this.$refs.audioplayer.load();
+                        } else if (this.selectedFileIs('video')) {
+                            this.$refs.videoplayer.load();
+                        }
+                    });
+                },
+            }
 		});
 
 
@@ -87,16 +98,16 @@ module.exports = function(){
 					var type = manager.selected_file.type;
 
 					var imageMimeTypes = ['image/jpeg', 'image/png', 'image/gif'];
-					
+
 					if (imageMimeTypes.indexOf(type) > -1) {
-						$('#imagemodal').modal('show');   
+						$('#imagemodal').modal('show');
 						return false;
 					}
-					
+
 					if (type !== "folder") {
 						return false;
 					}
-					
+
 					manager.folders.push(manager.selected_file.name);
 					getFiles(manager.folders);
 				});
@@ -111,7 +122,7 @@ module.exports = function(){
 
 				$('.breadcrumb').on("click", "li.media_breadcrumb", function(){
 					var index = $(this).data('index');
-					
+
 					manager.folders = manager.folders.splice(0, index);
 					getFiles(manager.folders);
 				});
@@ -123,7 +134,7 @@ module.exports = function(){
 					$('.breadcrumb-container .toggle .icon').toggleClass('fa-toggle-right').toggleClass('fa-toggle-left');
 				});
 
-				
+
 				//********** Add Keypress Functionality **********//
 				var isBrowsingFiles = null,
 				fileBrowserActive = function(el){
@@ -174,16 +185,16 @@ module.exports = function(){
 								var type = manager.selected_file.type;
 
 								var imageMimeTypes = ['image/jpeg', 'image/png', 'image/gif'];
-						
+
 								if (imageMimeTypes.indexOf(type) > -1) {
-									$('#imagemodal').modal('show');   
+									$('#imagemodal').modal('show');
 									return false;
 								}
-								
+
 								if (type !== "folder") {
 									return false;
 								}
-								
+
 								manager.folders.push(manager.selected_file.name);
 								getFiles(manager.folders);
 							}
@@ -199,7 +210,7 @@ module.exports = function(){
 						}
 					}
 				});
-				
+
 				//********** End Keypress Functionality **********//
 
 
@@ -304,7 +315,7 @@ module.exports = function(){
 						}
 					});
 				});
-				
+
 				// Crop Image
 				$('#crop').click(function(){
 					// Cleanup the previous cropper
@@ -424,12 +435,12 @@ module.exports = function(){
 					var i = parseInt(Math.floor(Math.log(bytes) / Math.log(1024)));
 					return Math.round(bytes / Math.pow(1024, i), 2) + ' ' + sizes[i];
 				}
-				
+
 				function cropImage(createMode) {
 					croppedData.originImageName = manager.selected_file.name
 					croppedData.upload_path = '/' + manager.folders.join('/')
 					croppedData.createMode = createMode
-	
+
 					var postData = Object.assign(croppedData, {_token: CSRF_TOKEN})
 					$.post(options.baseUrl+'/media/crop', postData, function(data){
 						if(data.success == true){
@@ -441,8 +452,8 @@ module.exports = function(){
 						}
 					});
 				}
-				
-				
+
+
 			}
 		};
 

--- a/resources/views/media/index.blade.php
+++ b/resources/views/media/index.blade.php
@@ -140,7 +140,7 @@
                                                 <img :src="selected_file.path"/>
                                             </template>
                                             <template v-if="selectedFileIs('video')">
-                                                <video width="100%" height="auto" controls>
+                                                <video width="100%" height="auto" ref="videoplayer" controls>
                                                     <source :src="selected_file.path" type="video/mp4">
                                                     <source :src="selected_file.path" type="video/ogg">
                                                     <source :src="selected_file.path" type="video/webm">
@@ -149,7 +149,7 @@
                                             </template>
                                             <template v-if="selectedFileIs('audio')">
                                                 <i class="voyager-music"></i>
-                                                <audio controls style="width:100%; margin-top:5px;">
+                                                <audio controls style="width:100%; margin-top:5px;" ref="audioplayer">
                                                     <source :src="selected_file.path" type="audio/ogg">
                                                     <source :src="selected_file.path" type="audio/mpeg">
                                                     {{ __('voyager::media.browser_audio_support') }}


### PR DESCRIPTION
Only the source of `video` and `audio` tags were changed when changing the selected file, but the tags itself needs to be `load()`ed.
Fixes https://github.com/the-control-group/voyager/issues/3479