### PR TITLE
Implementation of eager loading for belongsTo relationships

### DIFF
--- a/publishable/lang/en/database.php
+++ b/publishable/lang/en/database.php
@@ -83,5 +83,6 @@ return [
         'delete'               => 'Delete',
         'create'               => 'Create a Relationship',
         'namespace'            => 'Model Namespace (ex. App\Category)',
+        'method'               => 'Method (optional, eg. :table->method)',
     ],
 ];

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -10,12 +10,13 @@
 
                 @php
                     $relationshipData = (isset($data)) ? $data : $dataTypeContent;
-                    $model = app($options->model);
-                    $query = $model::find($relationshipData->{$options->column});
+                    $model = !empty($options->method)
+                    ? $relationshipData->{$options->method}
+                    : app($options->model)->find($relationshipData->{$options->column});
                 @endphp
 
-                @if(isset($query))
-                    <p>{{ $query->{$options->label} }}</p>
+                @if(isset($model))
+                    <p>{{ $model->{$options->label} }}</p>
                 @else
                     <p>{{ __('voyager::generic.no_results') }}</p>
                 @endif

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -27,7 +27,7 @@
     </div>
     <div class="col-xs-4">
         <div class="voyager-relationship-details-btn">
-            <i class="voyager-angle-down"></i><i class="voyager-angle-up"></i> 
+            <i class="voyager-angle-down"></i><i class="voyager-angle-up"></i>
             <span class="open_text">{{ __('voyager::database.relationship.open') }}</span>
             <span class="close_text">{{ __('voyager::database.relationship.close') }}</span>
             {{ __('voyager::database.relationship.relationship_details') }}
@@ -48,6 +48,7 @@
                     <option value="{{ $tablename }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tablename){{ 'selected="selected"' }}@endif>{{ ucfirst($tablename) }}</option>
                 @endforeach
             </select>
+            <span><input type="text" class="form-control" name="relationship_method_{{ $relationship['field'] }}" placeholder="{{ __('voyager::database.relationship.method', ['table' => $table]) }}" value="@if(isset($relationshipDetails->method)){{ $relationshipDetails->method }}@endif"></span>
             <span><input type="text" class="form-control" name="relationship_model_{{ $relationship['field'] }}" placeholder="{{ __('voyager::database.relationship.namespace') }}" value="@if(isset($relationshipDetails->model)){{ $relationshipDetails->model }}@endif"></span>
         </div>
             <div class="relationshipField">

--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -51,4 +51,21 @@ trait BreadRelationshipParser
 
         return $dataTypeContent instanceof LengthAwarePaginator ? $dataTypeContent->setCollection($dataTypeCollection) : $dataTypeCollection;
     }
+
+    /**
+     * Eager load relationships for index view (if 'method' is configured for the relationship)
+     *
+     * @param $query  The instance of query builder to update
+     * @param DataType $dataType
+     */
+    protected function eagerLoadRelationship($query, DataType $dataType)
+    {
+        $relationships = $dataType->browseRows->where('type', 'relationship');
+
+        foreach ($relationships as $row) {
+            if (!empty($row->details->method)) {
+                $query->with($row->details->method);
+            }
+        }
+    }
 }

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -65,6 +65,9 @@ class VoyagerBaseController extends Controller
             // If a column has a relationship associated with it, we do not want to show that field
             $this->removeRelationshipField($dataType, 'browse');
 
+            //Eager load relationships specifying a method
+            $this->eagerLoadRelationship($query, $dataType);
+
             if ($search->value && $search->key && $search->filter) {
                 $search_filter = ($search->filter == 'equals') ? '=' : 'LIKE';
                 $search_value = ($search->filter == 'equals') ? $search->value : '%'.$search->value.'%';

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -181,6 +181,7 @@ class DataType extends Model
                         'table'       => $requestData['relationship_table_'.$relationship],
                         'type'        => $requestData['relationship_type_'.$relationship],
                         'column'      => $relationship_column,
+                        'method'      => $requestData['relationship_method_'.$relationship],
                         'key'         => $requestData['relationship_key_'.$relationship],
                         'label'       => $requestData['relationship_label_'.$relationship],
                         'pivot_table' => $requestData['relationship_pivot_table_'.$relationship],


### PR DESCRIPTION
A work in progress in order to implement eager loading on BRED index views.

This requires specifying the relationship method when configuring the relation (optional):
![image](https://user-images.githubusercontent.com/1137276/52118357-accb0d80-2648-11e9-8e7e-fe8ed4b2e3b4.png)

If present the relation is used for eager loading and display, otherwise fallback to `Model::find()`
In `views/formfields/relationship`:
```php
@php
    $relationshipData = (isset($data)) ? $data : $dataTypeContent;
    $model = !empty($options->method)
    ? $relationshipData->{$options->method}
    : app($options->model)->find($relationshipData->{$options->column});
@endphp

@if(isset($model))
    <p>{{ $model->{$options->label} }}</p>
@else
    <p>{{ __('voyager::generic.no_results') }}</p>
@endif
```