### PR TITLE
Fix image create error on media upload

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -224,7 +224,7 @@ class VoyagerMediaController extends Controller
                 'image/svg+xml',
             ];
             if (in_array($request->file->getMimeType(), $imageMimeTypes)) {
-                $image = Image::make($realPath.$file);
+                $image = Image::make($request->file->getRealPath());
 
                 if ($request->file->getClientOriginalExtension() == 'gif') {
                     copy($request->file->getRealPath(), $realPath.$file);

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image;
@@ -214,8 +215,6 @@ class VoyagerMediaController extends Controller
                 $name = get_file_name($name);
             }
 
-            $file = $request->file->storeAs($request->upload_path, $name.'.'.$extension, $this->filesystem);
-
             $imageMimeTypes = [
                 'image/jpeg',
                 'image/png',
@@ -223,14 +222,21 @@ class VoyagerMediaController extends Controller
                 'image/bmp',
                 'image/svg+xml',
             ];
-            if (in_array($request->file->getMimeType(), $imageMimeTypes)) {
-                $image = Image::make($realPath.$file);
 
-                if ($request->file->getClientOriginalExtension() == 'gif') {
-                    copy($request->file->getRealPath(), $realPath.$file);
-                } else {
-                    $image->orientate()->save($realPath.$file);
+            if (in_array($request->file->getMimeType(), $imageMimeTypes)) {
+                $image = Image::make($request->file->getRealPath());
+
+                if (strtolower($request->file->getClientOriginalExtension()) !== 'gif') {
+                    $rotatedPath = $request->file->getRealPath() . 'rotated';
+                    $image->orientate()->save($rotatedPath);
+                    $request->file = new UploadedFile($rotatedPath, basename($rotatedPath), $request->file->getMimeType(), null, false);
                 }
+            }
+
+            $file = $request->file->storeAs($request->upload_path, $name.'.'.$extension, $this->filesystem);
+
+            if (isset($rotatedPath)) {
+                unlink($rotatedPath);
             }
 
             $success = true;
@@ -331,7 +337,7 @@ class VoyagerMediaController extends Controller
 
                 // Check if we're dealing with a nested array for the case of multiple files
                 if (is_array($fieldData[0])) {
-                    foreach ($fieldData as $index=>$file) {
+                    foreach ($fieldData as $index => $file) {
                         $file = array_flip($file);
                         if (array_key_exists($filename, $file)) {
                             $key = $index;

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -227,7 +227,7 @@ class VoyagerMediaController extends Controller
                 $image = Image::make($request->file->getRealPath());
 
                 if (strtolower($request->file->getClientOriginalExtension()) !== 'gif') {
-                    $rotatedPath = $request->file->getRealPath() . 'rotated';
+                    $rotatedPath = $request->file->getRealPath().'rotated';
                     $image->orientate()->save($rotatedPath);
                     $request->file = new UploadedFile($rotatedPath, basename($rotatedPath), $request->file->getMimeType(), null, false);
                 }


### PR DESCRIPTION
realPath.file on line 227 doesn't exist yet because it has not been written yet - it gets written to the file system at line 230 with the copy function.

An exception occurs but the file gets written anyway. This patch stops the exception.

Steps to reproduce:
1) Navigate to media section
2) Open network tab in console
3) Upload an image to root folder (I was uploading a png ~ 30kb)
4) 500 error happens on /admin/media/upload

(laravel/framework 5.7.25, php 7.2.14, intervention/image 2.4.2, filesystem driver: s3)