### PR TITLE
Let developers use a separate guard for auth users

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -40,8 +40,8 @@
                     <li class="profile-img">
                         <img src="{{ $user_avatar }}" class="profile-img">
                         <div class="profile-body">
-                            <h5>{{ Auth::user()->name }}</h5>
-                            <h6>{{ Auth::user()->email }}</h6>
+                            <h5>{{ Auth::guard('admin')->user()->name }}</h5>
+                            <h6>{{ Auth::guard('admin')->user()->email }}</h6>
                         </div>
                     </li>
                     <li class="divider"></li>

--- a/resources/views/dashboard/sidebar.blade.php
+++ b/resources/views/dashboard/sidebar.blade.php
@@ -19,9 +19,9 @@
                  style="background-image:url({{ Voyager::image( Voyager::setting('admin.bg_image'), voyager_asset('images/bg.jpg') ) }}); background-size: cover; background-position: 0px;">
                 <div class="dimmer"></div>
                 <div class="panel-content">
-                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ Auth::user()->name }} avatar">
-                    <h4>{{ ucwords(Auth::user()->name) }}</h4>
-                    <p>{{ Auth::user()->email }}</p>
+                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ Auth::guard('admin')->user()->name }} avatar">
+                    <h4>{{ ucwords(Auth::guard('admin')->user()->name) }}</h4>
+                    <p>{{ Auth::guard('admin')->user()->email }}</p>
 
                     <a href="{{ route('voyager.profile') }}" class="btn btn-primary">{{ __('voyager::generic.profile') }}</a>
                     <div style="clear:both"></div>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -11,8 +11,6 @@
     <!-- Favicon -->
     <link rel="shortcut icon" href="{{ voyager_asset('images/logo-icon.png') }}" type="image/x-icon">
 
-
-
     <!-- App CSS -->
     <link rel="stylesheet" href="{{ voyager_asset('css/app.css') }}">
 
@@ -58,10 +56,10 @@
 </div>
 
 <?php
-if (starts_with(Auth::user()->avatar, 'http://') || starts_with(Auth::user()->avatar, 'https://')) {
-    $user_avatar = Auth::user()->avatar;
+if (starts_with(Auth::guard('admin')->user()->avatar, 'http://') || starts_with(Auth::guard('admin')->user()->avatar, 'https://')) {
+    $user_avatar = Auth::guard('admin')->user()->avatar;
 } else {
-    $user_avatar = Voyager::image(Auth::user()->avatar);
+    $user_avatar = Voyager::image(Auth::guard('admin')->user()->avatar);
 }
 ?>
 

--- a/resources/views/menu/admin_menu.blade.php
+++ b/resources/views/menu/admin_menu.blade.php
@@ -32,7 +32,7 @@
         {
             foreach($item->children as $child)
             {
-                $hasChildren = $hasChildren || Auth::user()->can('browse', $child);
+                $hasChildren = $hasChildren || Auth::guard('admin')->user()->can('browse', $child);
 
                 if(url($child->link()) == url()->current())
                 {

--- a/resources/views/menu/admin_menu.blade.php
+++ b/resources/views/menu/admin_menu.blade.php
@@ -50,7 +50,7 @@
         {
             $linkAttributes =  'href="' . url($href) .'"';
 
-            if(!Auth::user()->can('browse', $item)) {
+            if(!Auth::guard('admin')->user()->can('browse', $item)) {
                 continue;
             }
         }

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -13,13 +13,13 @@
     <div style="background-size:cover; background-image: url({{ Voyager::image( Voyager::setting('admin.bg_image'), config('voyager.assets_path') . '/images/bg.jpg') }}); background-position: center center;position:absolute; top:0; left:0; width:100%; height:300px;"></div>
     <div style="height:160px; display:block; width:100%"></div>
     <div style="position:relative; z-index:9; text-align:center;">
-        <img src="@if( !filter_var(Auth::user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( Auth::user()->avatar ) }}@else{{ Auth::user()->avatar }}@endif"
+        <img src="@if( !filter_var(Auth::guard('admin')->user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( Auth::guard('admin')->user()->avatar ) }}@else{{ Auth::guard('admin')->user()->avatar }}@endif"
              class="avatar"
              style="border-radius:50%; width:150px; height:150px; border:5px solid #fff;"
-             alt="{{ Auth::user()->name }} avatar">
-        <h4>{{ ucwords(Auth::user()->name) }}</h4>
-        <div class="user-email text-muted">{{ ucwords(Auth::user()->email) }}</div>
-        <p>{{ Auth::user()->bio }}</p>
-        <a href="{{ route('voyager.users.edit', Auth::user()->id) }}" class="btn btn-primary">{{ __('voyager::profile.edit') }}</a>
+             alt="{{ Auth::guard('admin')->user()->name }} avatar">
+        <h4>{{ ucwords(Auth::guard('admin')->user()->name) }}</h4>
+        <div class="user-email text-muted">{{ ucwords(Auth::guard('admin')->user()->email) }}</div>
+        <p>{{ Auth::guard('admin')->user()->bio }}</p>
+        <a href="{{ route('voyager.users.edit', Auth::guard('admin')->user()->id) }}" class="btn btn-primary">{{ __('voyager::profile.edit') }}</a>
     </div>
 @stop

--- a/src/Http/Controllers/VoyagerAuthController.php
+++ b/src/Http/Controllers/VoyagerAuthController.php
@@ -35,7 +35,7 @@ class VoyagerAuthController extends Controller
 
         $credentials = $this->credentials($request);
 
-        if ($this->guard()->attempt($credentials, $request->has('remember'))) {
+        if (Auth::guard('admin')->attempt($credentials, $request->has('remember'))) {
             return $this->sendLoginResponse($request);
         }
 

--- a/src/Http/Controllers/VoyagerAuthController.php
+++ b/src/Http/Controllers/VoyagerAuthController.php
@@ -13,7 +13,7 @@ class VoyagerAuthController extends Controller
 
     public function login()
     {
-        if (Auth::user()) {
+        if (Auth::guard('admin')->user()) {
             return redirect()->route('voyager.dashboard');
         }
 

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -18,8 +18,8 @@ class VoyagerAdminMiddleware
      */
     public function handle($request, Closure $next)
     {
-        if (!Auth::guest()) {
-            $user = auth()->user();
+        if (!Auth::guard('admin')->guest()) {
+            $user = Auth::guard('admin')->user();
             if (isset($user->locale)) {
                 app()->setLocale($user->locale);
             }

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -30,8 +30,8 @@ class Page extends Model
     public function save(array $options = [])
     {
         // If no author has been assigned, assign the current user's id as the author of the post
-        if (!$this->author_id && Auth::user()) {
-            $this->author_id = Auth::user()->id;
+        if (!$this->author_id && Auth::guard('admin')->user()) {
+            $this->author_id = Auth::guard('admin')->user()->id;
         }
 
         parent::save();

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -23,8 +23,8 @@ class Post extends Model
     public function save(array $options = [])
     {
         // If no author has been assigned, assign the current user's id as the author of the post
-        if (!$this->author_id && Auth::user()) {
-            $this->author_id = Auth::user()->id;
+        if (!$this->author_id && Auth::guard('admin')->user()) {
+            $this->author_id = Auth::guard('admin')->user()->id;
         }
 
         parent::save();

--- a/src/Traits/VoyagerUser.php
+++ b/src/Traits/VoyagerUser.php
@@ -117,6 +117,9 @@ trait VoyagerUser
     private function loadPermissionsRelations()
     {
         $this->loadRolesRelations();
+        
+        if(!$this->role)
+            $this->role = Role::find( Auth::user()->role_id );
 
         if (!$this->role->relationLoaded('permissions')) {
             $this->role->load('permissions');

--- a/src/Widgets/PageDimmer.php
+++ b/src/Widgets/PageDimmer.php
@@ -43,6 +43,6 @@ class PageDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return Auth::user()->can('browse', Voyager::model('Page'));
+        return Auth::guard('admin')->user()->can('browse', Voyager::model('Page'));
     }
 }

--- a/src/Widgets/PostDimmer.php
+++ b/src/Widgets/PostDimmer.php
@@ -43,6 +43,6 @@ class PostDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return Auth::user()->can('browse', Voyager::model('Post'));
+        return Auth::guard('admin')->user()->can('browse', Voyager::model('Post'));
     }
 }

--- a/src/Widgets/UserDimmer.php
+++ b/src/Widgets/UserDimmer.php
@@ -43,6 +43,6 @@ class UserDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return Auth::user()->can('browse', Voyager::model('User'));
+        return Auth::guard('admin')->user()->can('browse', Voyager::model('User'));
     }
 }


### PR DESCRIPTION
Most of us doesn't use the same guard (user guard) for both of admins and front users.

I'm not exception. I have two guards - users and admins. And I couldn't use your awesome package because of hardcoded auth guards.

In this PR you can see 12 changed  files, where I decided to separate the front and admin users guards.