### PR TITLE
Laravel 5.8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ View the Voyager Cheat Sheet: https://voyager-cheatsheet.ulties.com/
 
 <hr>
 
-Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.5, 5.6, 5.7 and 5.8!
+Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.4, 5.5, 5.6, 5.7 and 5.8!
 
 ## Installation Steps
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ View the Voyager Cheat Sheet: https://voyager-cheatsheet.ulties.com/
 
 <hr>
 
-Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.4, 5.5, 5.6, 5.7 and 5.8!
+Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.5, 5.6, 5.7 and 5.8!
 
 ## Installation Steps
 
 ### 1. Require the Package
 
-After creating your new Laravel application you can include the Voyager package with the following command: 
+After creating your new Laravel application you can include the Voyager package with the following command:
 
 ```bash
 composer require tcg/voyager

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ View the Voyager Cheat Sheet: https://voyager-cheatsheet.ulties.com/
 
 <hr>
 
-Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.4, 5.5, 5.6 and 5.7!
+Laravel Admin & BREAD System (Browse, Read, Edit, Add, & Delete), supporting Laravel 5.4, 5.5, 5.6, 5.7 and 5.8!
 
 ## Installation Steps
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0",
+        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",
         "larapack/doctrine-support": "~0.1.4",
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpunit/phpcov": "~3.0|~4.0",
         "phpunit/phpunit": "~5.7.14|~6.1|~7.0",
-        "laravel/framework": "~5.4.36|~5.5.0|~5.6.0",
+        "laravel/framework": "~5.4.36|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "orchestra/testbench": "~3.4.11|~3.5.0|~3.6.0",
         "orchestra/database": "~3.4.0|~3.5.0|~3.6.0",
         "orchestra/testbench-core": "~3.4.5|~3.5.0|~3.6.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",
         "larapack/doctrine-support": "~0.1.4",
@@ -27,12 +27,12 @@
     "require-dev": {
         "phpunit/phpcov": "~3.0|~4.0",
         "phpunit/phpunit": "~5.7.14|~6.1|~7.0",
-        "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0",
-        "orchestra/database": "~3.5.0|~3.6.0",
-        "orchestra/testbench-core": "~3.5.0|~3.6.0",
+        "laravel/framework": "~5.4.36|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "orchestra/testbench": "~3.4.11|~3.5.0|~3.6.0",
+        "orchestra/database": "~3.4.0|~3.5.0|~3.6.0",
+        "orchestra/testbench-core": "~3.4.5|~3.5.0|~3.6.0",
         "laravel/browser-kit-testing": "~1.0.0|~2.0.0",
-        "orchestra/testbench-browser-kit": "~3.5.0|~3.6.0"
+        "orchestra/testbench-browser-kit": "~3.4.1|~3.5.0|~3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         "phpunit/phpcov": "~3.0|~4.0",
         "phpunit/phpunit": "~5.7.14|~6.1|~7.0",
         "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
-        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
-        "orchestra/testbench-core": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0",
+        "orchestra/database": "~3.5.0|~3.6.0",
+        "orchestra/testbench-core": "~3.5.0|~3.6.0",
         "laravel/browser-kit-testing": "~1.0.0|~2.0.0",
-        "orchestra/testbench-browser-kit": "~3.5.0|~3.6.0|~3.7.0|3.8.0"
+        "orchestra/testbench-browser-kit": "~3.5.0|~3.6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "illuminate/support": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",
         "larapack/doctrine-support": "~0.1.4",
@@ -27,12 +27,12 @@
     "require-dev": {
         "phpunit/phpcov": "~3.0|~4.0",
         "phpunit/phpunit": "~5.7.14|~6.1|~7.0",
-        "laravel/framework": "~5.4.36|~5.5.0|~5.6.0|~5.7.0|~5.8.0",
-        "orchestra/testbench": "~3.4.11|~3.5.0|~3.6.0",
-        "orchestra/database": "~3.4.0|~3.5.0|~3.6.0",
-        "orchestra/testbench-core": "~3.4.5|~3.5.0|~3.6.0",
+        "laravel/framework": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
+        "orchestra/testbench": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
+        "orchestra/database": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
+        "orchestra/testbench-core": "~3.5.0|~3.6.0|~3.7.0|3.8.0",
         "laravel/browser-kit-testing": "~1.0.0|~2.0.0",
-        "orchestra/testbench-browser-kit": "~3.4.1|~3.5.0|~3.6.0"
+        "orchestra/testbench-browser-kit": "~3.5.0|~3.6.0|~3.7.0|3.8.0"
     },
     "autoload": {
         "psr-4": {

--- a/migrations/2016_01_01_000000_add_voyager_user_fields.php
+++ b/migrations/2016_01_01_000000_add_voyager_user_fields.php
@@ -13,7 +13,7 @@ class AddVoyagerUserFields extends Migration
             if (!Schema::hasColumn('users', 'avatar')) {
                 $table->string('avatar')->nullable()->after('email')->default('users/default.png');
             }
-            $table->integer('role_id')->nullable()->after('id');
+            $table->bigInteger('role_id')->nullable()->after('id');
         });
     }
 

--- a/migrations/2016_10_21_190000_create_roles_table.php
+++ b/migrations/2016_10_21_190000_create_roles_table.php
@@ -14,7 +14,7 @@ class CreateRolesTable extends Migration
     public function up()
     {
         Schema::create('roles', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('name')->unique();
             $table->string('display_name');
             $table->timestamps();

--- a/migrations/2016_11_30_135954_create_permission_table.php
+++ b/migrations/2016_11_30_135954_create_permission_table.php
@@ -14,7 +14,7 @@ class CreatePermissionTable extends Migration
     public function up()
     {
         Schema::create('permissions', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('key')->index();
             $table->string('table_name');
             $table->timestamps();

--- a/migrations/2016_11_30_141208_create_permission_role_table.php
+++ b/migrations/2016_11_30_141208_create_permission_role_table.php
@@ -14,9 +14,9 @@ class CreatePermissionRoleTable extends Migration
     public function up()
     {
         Schema::create('permission_role', function (Blueprint $table) {
-            $table->integer('permission_id')->unsigned()->index();
+            $table->bigInteger('permission_id')->unsigned()->index();
             $table->foreign('permission_id')->references('id')->on('permissions')->onDelete('cascade');
-            $table->integer('role_id')->unsigned()->index();
+            $table->bigInteger('role_id')->unsigned()->index();
             $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
             $table->primary(['permission_id', 'role_id']);
         });

--- a/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -14,7 +14,7 @@ class AddUserRoleRelationship extends Migration
     public function up()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->unsignedInteger('role_id')->change();
+            $table->bigInteger('role_id')->unsigned()->change();
             $table->foreign('role_id')->references('id')->on('roles');
         });
     }
@@ -31,7 +31,7 @@ class AddUserRoleRelationship extends Migration
         });
 
         Schema::table('users', function (Blueprint $table) {
-            $table->integer('role_id')->change();
+            $table->bigInteger('role_id')->change();
         });
     }
 }

--- a/migrations/2017_11_26_015000_create_user_roles_table.php
+++ b/migrations/2017_11_26_015000_create_user_roles_table.php
@@ -14,9 +14,9 @@ class CreateUserRolesTable extends Migration
     public function up()
     {
         Schema::create('user_roles', function (Blueprint $table) {
-            $table->integer('user_id')->unsigned()->index();
+            $table->bigInteger('user_id')->unsigned()->index();
             $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
-            $table->integer('role_id')->unsigned()->index();
+            $table->bigInteger('role_id')->unsigned()->index();
             $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
             $table->primary(['user_id', 'role_id']);
         });

--- a/publishable/database/dummy_seeds/UsersTableSeeder.php
+++ b/publishable/database/dummy_seeds/UsersTableSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\User;
 
@@ -20,7 +21,7 @@ class UsersTableSeeder extends Seeder
                 'name'           => 'Admin',
                 'email'          => 'admin@admin.com',
                 'password'       => bcrypt('password'),
-                'remember_token' => str_random(60),
+                'remember_token' => Str::random(60),
                 'role_id'        => $role->id,
             ]);
         }

--- a/resources/views/formfields/radio_btn.blade.php
+++ b/resources/views/formfields/radio_btn.blade.php
@@ -10,10 +10,10 @@
     @if(isset($options->options))
         @foreach($options->options as $key => $option)
             <li>
-                <input type="radio" id="option-{{ \Str::slug($row->field, '-') }}-{{ \Str::slug($key, '-') }}"
+                <input type="radio" id="option-{{ \Illuminate\Support\Str::slug($row->field, '-') }}-{{ \Illuminate\Support\Str::slug($key, '-') }}"
                        name="{{ $row->field }}"
                        value="{{ $key }}" @if($default == $key && $selected_value === NULL){{ 'checked' }}@endif @if($selected_value == $key){{ 'checked' }}@endif>
-                <label for="option-{{ \Str::slug($row->field, '-') }}-{{ \Str::slug($key, '-') }}">{{ $option }}</label>
+                <label for="option-{{ \Illuminate\Support\Str::slug($row->field, '-') }}-{{ \Illuminate\Support\Str::slug($key, '-') }}">{{ $option }}</label>
                 <div class="check"></div>
             </li>
         @endforeach

--- a/resources/views/formfields/radio_btn.blade.php
+++ b/resources/views/formfields/radio_btn.blade.php
@@ -10,10 +10,10 @@
     @if(isset($options->options))
         @foreach($options->options as $key => $option)
             <li>
-                <input type="radio" id="option-{{ Str::slug($row->field, '-') }}-{{ Str::slug($key, '-') }}"
+                <input type="radio" id="option-{{ \Str::slug($row->field, '-') }}-{{ \Str::slug($key, '-') }}"
                        name="{{ $row->field }}"
                        value="{{ $key }}" @if($default == $key && $selected_value === NULL){{ 'checked' }}@endif @if($selected_value == $key){{ 'checked' }}@endif>
-                <label for="option-{{ Str::slug($row->field, '-') }}-{{ Str::slug($key, '-') }}">{{ $option }}</label>
+                <label for="option-{{ \Str::slug($row->field, '-') }}-{{ \Str::slug($key, '-') }}">{{ $option }}</label>
                 <div class="check"></div>
             </li>
         @endforeach

--- a/resources/views/formfields/radio_btn.blade.php
+++ b/resources/views/formfields/radio_btn.blade.php
@@ -10,10 +10,10 @@
     @if(isset($options->options))
         @foreach($options->options as $key => $option)
             <li>
-                <input type="radio" id="option-{{ str_slug($row->field, '-') }}-{{ str_slug($key, '-') }}"
+                <input type="radio" id="option-{{ Str::slug($row->field, '-') }}-{{ Str::slug($key, '-') }}"
                        name="{{ $row->field }}"
                        value="{{ $key }}" @if($default == $key && $selected_value === NULL){{ 'checked' }}@endif @if($selected_value == $key){{ 'checked' }}@endif>
-                <label for="option-{{ str_slug($row->field, '-') }}-{{ str_slug($key, '-') }}">{{ $option }}</label>
+                <label for="option-{{ Str::slug($row->field, '-') }}-{{ Str::slug($key, '-') }}">{{ $option }}</label>
                 <div class="check"></div>
             </li>
         @endforeach

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -156,7 +156,7 @@
                     data-get-items-route="{{route('voyager.' . $dataType->slug.'.relation')}}"
                     data-get-items-field="{{$row->field}}"
                     @if(isset($options->taggable) && $options->taggable == 'on')
-                        data-route="{{ route('voyager.'.\Str::slug($options->table).'.store') }}"
+                        data-route="{{ route('voyager.'.\Illuminate\Support\Str::slug($options->table).'.store') }}"
                         data-label="{{$options->label}}"
                         data-error-message="{{__('voyager::bread.error_tagging')}}"
                     @endif

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -156,7 +156,7 @@
                     data-get-items-route="{{route('voyager.' . $dataType->slug.'.relation')}}"
                     data-get-items-field="{{$row->field}}"
                     @if(isset($options->taggable) && $options->taggable == 'on')
-                        data-route="{{ route('voyager.'.Str::slug($options->table).'.store') }}"
+                        data-route="{{ route('voyager.'.\Str::slug($options->table).'.store') }}"
                         data-label="{{$options->label}}"
                         data-error-message="{{__('voyager::bread.error_tagging')}}"
                     @endif

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -156,7 +156,7 @@
                     data-get-items-route="{{route('voyager.' . $dataType->slug.'.relation')}}"
                     data-get-items-field="{{$row->field}}"
                     @if(isset($options->taggable) && $options->taggable == 'on')
-                        data-route="{{ route('voyager.'.str_slug($options->table).'.store') }}"
+                        data-route="{{ route('voyager.'.Str::slug($options->table).'.store') }}"
                         data-label="{{$options->label}}"
                         data-error-message="{{__('voyager::bread.error_tagging')}}"
                     @endif

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -236,14 +236,14 @@
                     <ul class="nav nav-tabs">
                         @foreach($settings as $group => $setting)
                             <li @if($group == $active) class="active" @endif>
-                                <a data-toggle="tab" href="#{{ \Str::slug($group) }}">{{ $group }}</a>
+                                <a data-toggle="tab" href="#{{ \Illuminate\Support\Str::slug($group) }}">{{ $group }}</a>
                             </li>
                         @endforeach
                     </ul>
 
                     <div class="tab-content">
                         @foreach($settings as $group => $group_settings)
-                        <div id="{{ \Str::slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
+                        <div id="{{ \Illuminate\Support\Str::slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
                             @foreach($group_settings as $setting)
                             <div class="panel-heading">
                                 <h3 class="panel-title">

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -236,14 +236,14 @@
                     <ul class="nav nav-tabs">
                         @foreach($settings as $group => $setting)
                             <li @if($group == $active) class="active" @endif>
-                                <a data-toggle="tab" href="#{{ Str::slug($group) }}">{{ $group }}</a>
+                                <a data-toggle="tab" href="#{{ \Str::slug($group) }}">{{ $group }}</a>
                             </li>
                         @endforeach
                     </ul>
 
                     <div class="tab-content">
                         @foreach($settings as $group => $group_settings)
-                        <div id="{{ Str::slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
+                        <div id="{{ \Str::slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
                             @foreach($group_settings as $setting)
                             <div class="panel-heading">
                                 <h3 class="panel-title">

--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -236,14 +236,14 @@
                     <ul class="nav nav-tabs">
                         @foreach($settings as $group => $setting)
                             <li @if($group == $active) class="active" @endif>
-                                <a data-toggle="tab" href="#{{ str_slug($group) }}">{{ $group }}</a>
+                                <a data-toggle="tab" href="#{{ Str::slug($group) }}">{{ $group }}</a>
                             </li>
                         @endforeach
                     </ul>
 
                     <div class="tab-content">
                         @foreach($settings as $group => $group_settings)
-                        <div id="{{ str_slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
+                        <div id="{{ Str::slug($group) }}" class="tab-pane fade in @if($group == $active) active @endif">
                             @foreach($group_settings as $setting)
                             <div class="panel-heading">
                                 <h3 class="panel-title">

--- a/resources/views/tools/bread/relationship-new-modal.blade.php
+++ b/resources/views/tools/bread/relationship-new-modal.blade.php
@@ -6,7 +6,7 @@
 		        <div class="modal-header">
 	                <button type="button" class="close" data-dismiss="modal"
 	                        aria-hidden="true">&times;</button>
-	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ Str::singular(ucfirst($table)) }} 
+	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ \Str::singular(ucfirst($table)) }}
 					{{ __('voyager::database.relationship.relationships') }} </h4>
 	            </div>
 
@@ -15,7 +15,7 @@
 
 			        	@if(isset($dataType->id))
 				            <div class="col-md-12 relationship_details">
-				                <p class="relationship_table_select">{{ Str::singular(ucfirst($table)) }}</p>
+				                <p class="relationship_table_select">{{ \Str::singular(ucfirst($table)) }}</p>
 				                <select class="relationship_type select2" name="relationship_type">
 				                    <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
 				                    <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -24,14 +24,14 @@
 				                </select>
 				                <select class="relationship_table select2" name="relationship_table">
 				                    @foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 				                </select>
 				                <span><input type="text" class="form-control" name="relationship_model" placeholder="{{ __('voyager::database.relationship.namespace') }}" value="@if(isset($relationshipDetails->model)){{ $relationshipDetails->model }}@endif"></span>
 				            </div>
 				            <div class="col-md-12 relationship_details relationshipField">
 				            	<div class="belongsTo">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
 				            		<select name="relationship_column_belongs_to" class="new_relationship_field select2">
 				                    	@foreach($fieldOptions as $data)
 				                        	<option value="{{ $data['field'] }}">{{ $data['field'] }}</option>
@@ -39,7 +39,7 @@
 				               		</select>
 				               	</div>
 				               	<div class="hasOneMany flexed">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ Str::singular(ucfirst($table)) }}</span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Str::singular(ucfirst($table)) }}</span>?</label>
 					                <select name="relationship_column" class="new_relationship_field select2 rowDrop" data-table="{{ $tables[0] }}" data-selected="">
 					                </select>
 					            </div>
@@ -48,7 +48,7 @@
 				            	<label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
 				            	<select name="relationship_pivot" class="select2">
 		                        	@foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 		                        </select>
 				            </div>

--- a/resources/views/tools/bread/relationship-new-modal.blade.php
+++ b/resources/views/tools/bread/relationship-new-modal.blade.php
@@ -6,7 +6,7 @@
 		        <div class="modal-header">
 	                <button type="button" class="close" data-dismiss="modal"
 	                        aria-hidden="true">&times;</button>
-	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ str_singular(ucfirst($table)) }} 
+	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ Str::singular(ucfirst($table)) }} 
 					{{ __('voyager::database.relationship.relationships') }} </h4>
 	            </div>
 
@@ -15,7 +15,7 @@
 
 			        	@if(isset($dataType->id))
 				            <div class="col-md-12 relationship_details">
-				                <p class="relationship_table_select">{{ str_singular(ucfirst($table)) }}</p>
+				                <p class="relationship_table_select">{{ Str::singular(ucfirst($table)) }}</p>
 				                <select class="relationship_type select2" name="relationship_type">
 				                    <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
 				                    <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -24,14 +24,14 @@
 				                </select>
 				                <select class="relationship_table select2" name="relationship_table">
 				                    @foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ str_singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 				                </select>
 				                <span><input type="text" class="form-control" name="relationship_model" placeholder="{{ __('voyager::database.relationship.namespace') }}" value="@if(isset($relationshipDetails->model)){{ $relationshipDetails->model }}@endif"></span>
 				            </div>
 				            <div class="col-md-12 relationship_details relationshipField">
 				            	<div class="belongsTo">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ str_singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
 				            		<select name="relationship_column_belongs_to" class="new_relationship_field select2">
 				                    	@foreach($fieldOptions as $data)
 				                        	<option value="{{ $data['field'] }}">{{ $data['field'] }}</option>
@@ -39,7 +39,7 @@
 				               		</select>
 				               	</div>
 				               	<div class="hasOneMany flexed">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ str_singular(ucfirst($table)) }}</span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ Str::singular(ucfirst($table)) }}</span>?</label>
 					                <select name="relationship_column" class="new_relationship_field select2 rowDrop" data-table="{{ $tables[0] }}" data-selected="">
 					                </select>
 					            </div>
@@ -48,7 +48,7 @@
 				            	<label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
 				            	<select name="relationship_pivot" class="select2">
 		                        	@foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ str_singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 		                        </select>
 				            </div>

--- a/resources/views/tools/bread/relationship-new-modal.blade.php
+++ b/resources/views/tools/bread/relationship-new-modal.blade.php
@@ -6,7 +6,7 @@
 		        <div class="modal-header">
 	                <button type="button" class="close" data-dismiss="modal"
 	                        aria-hidden="true">&times;</button>
-	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ \Str::singular(ucfirst($table)) }}
+	                <h4 class="modal-title"><i class="voyager-heart"></i> {{ \Illuminate\Support\Str::singular(ucfirst($table)) }}
 					{{ __('voyager::database.relationship.relationships') }} </h4>
 	            </div>
 
@@ -15,7 +15,7 @@
 
 			        	@if(isset($dataType->id))
 				            <div class="col-md-12 relationship_details">
-				                <p class="relationship_table_select">{{ \Str::singular(ucfirst($table)) }}</p>
+				                <p class="relationship_table_select">{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</p>
 				                <select class="relationship_type select2" name="relationship_type">
 				                    <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
 				                    <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -24,14 +24,14 @@
 				                </select>
 				                <select class="relationship_table select2" name="relationship_table">
 				                    @foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Illuminate\Support\Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 				                </select>
 				                <span><input type="text" class="form-control" name="relationship_model" placeholder="{{ __('voyager::database.relationship.namespace') }}" value="@if(isset($relationshipDetails->model)){{ $relationshipDetails->model }}@endif"></span>
 				            </div>
 				            <div class="col-md-12 relationship_details relationshipField">
 				            	<div class="belongsTo">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
 				            		<select name="relationship_column_belongs_to" class="new_relationship_field select2">
 				                    	@foreach($fieldOptions as $data)
 				                        	<option value="{{ $data['field'] }}">{{ $data['field'] }}</option>
@@ -39,7 +39,7 @@
 				               		</select>
 				               	</div>
 				               	<div class="hasOneMany flexed">
-				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Str::singular(ucfirst($table)) }}</span>?</label>
+				            		<label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span>?</label>
 					                <select name="relationship_column" class="new_relationship_field select2 rowDrop" data-table="{{ $tables[0] }}" data-selected="">
 					                </select>
 					            </div>
@@ -48,7 +48,7 @@
 				            	<label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
 				            	<select name="relationship_pivot" class="select2">
 		                        	@foreach($tables as $tbl)
-				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
+				                        <option value="{{ $tbl }}" @if(isset($relationshipDetails->table) && $relationshipDetails->table == $tbl){{ 'selected="selected"' }}@endif>{{ \Illuminate\Support\Str::singular(ucfirst($tbl)) }}</option>
 				                    @endforeach
 		                        </select>
 				            </div>

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -36,7 +36,7 @@
     <div class="col-md-12 voyager-relationship-details">
         <a href="{{ route('voyager.bread.delete_relationship', $relationship['id']) }}" class="delete_relationship"><i class="voyager-trash"></i> {{ __('voyager::database.relationship.delete') }}</a>
         <div class="relationship_details_content">
-            <p class="relationship_table_select">{{ \Str::singular(ucfirst($table)) }}</p>
+            <p class="relationship_table_select">{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</p>
             <select class="relationship_type select2" name="relationship_type_{{ $relationship['field'] }}">
                 <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
                 <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -52,7 +52,7 @@
         </div>
             <div class="relationshipField">
                 <div class="relationship_details_content margin_top belongsTo @if($relationshipDetails->type == 'belongsTo'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
                     <select name="relationship_column_belongs_to_{{ $relationship['field'] }}" class="new_relationship_field select2">
                         @foreach($fieldOptions as $data)
                             <option value="{{ $data['field'] }}" @if($relationshipDetails->column == $data['field']){{ 'selected="selected"' }}@endif>{{ $data['field'] }}</option>
@@ -61,7 +61,7 @@
                 </div>
 
                 <div class="relationship_details_content margin_top hasOneMany @if($relationshipDetails->type == 'hasOne' || $relationshipDetails->type == 'hasMany'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Str::singular(ucfirst($table)) }}</span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span>?</label>
                     <select name="relationship_column_{{ $relationship['field'] }}" class="new_relationship_field select2 rowDrop" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="{{ $relationshipDetails->column }}">
                     </select>
                 </div>
@@ -70,7 +70,7 @@
             <label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
             <select name="relationship_pivot_table_{{ $relationship['field'] }}" class="select2">
                 @foreach($tables as $tbl)
-                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
+                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ \Illuminate\Support\Str::singular(ucfirst($tbl)) }}</option>
                 @endforeach
             </select>
         </div>

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -36,7 +36,7 @@
     <div class="col-md-12 voyager-relationship-details">
         <a href="{{ route('voyager.bread.delete_relationship', $relationship['id']) }}" class="delete_relationship"><i class="voyager-trash"></i> {{ __('voyager::database.relationship.delete') }}</a>
         <div class="relationship_details_content">
-            <p class="relationship_table_select">{{ Str::singular(ucfirst($table)) }}</p>
+            <p class="relationship_table_select">{{ \Str::singular(ucfirst($table)) }}</p>
             <select class="relationship_type select2" name="relationship_type_{{ $relationship['field'] }}">
                 <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
                 <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -52,7 +52,7 @@
         </div>
             <div class="relationshipField">
                 <div class="relationship_details_content margin_top belongsTo @if($relationshipDetails->type == 'belongsTo'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ \Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
                     <select name="relationship_column_belongs_to_{{ $relationship['field'] }}" class="new_relationship_field select2">
                         @foreach($fieldOptions as $data)
                             <option value="{{ $data['field'] }}" @if($relationshipDetails->column == $data['field']){{ 'selected="selected"' }}@endif>{{ $data['field'] }}</option>
@@ -61,7 +61,7 @@
                 </div>
 
                 <div class="relationship_details_content margin_top hasOneMany @if($relationshipDetails->type == 'hasOne' || $relationshipDetails->type == 'hasMany'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ Str::singular(ucfirst($table)) }}</span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ \Str::singular(ucfirst($table)) }}</span>?</label>
                     <select name="relationship_column_{{ $relationship['field'] }}" class="new_relationship_field select2 rowDrop" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="{{ $relationshipDetails->column }}">
                     </select>
                 </div>
@@ -70,7 +70,7 @@
             <label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
             <select name="relationship_pivot_table_{{ $relationship['field'] }}" class="select2">
                 @foreach($tables as $tbl)
-                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
+                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ \Str::singular(ucfirst($tbl)) }}</option>
                 @endforeach
             </select>
         </div>

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -27,7 +27,7 @@
     </div>
     <div class="col-xs-4">
         <div class="voyager-relationship-details-btn">
-            <i class="voyager-angle-down"></i><i class="voyager-angle-up"></i> 
+            <i class="voyager-angle-down"></i><i class="voyager-angle-up"></i>
             <span class="open_text">{{ __('voyager::database.relationship.open') }}</span>
             <span class="close_text">{{ __('voyager::database.relationship.close') }}</span>
             {{ __('voyager::database.relationship.relationship_details') }}
@@ -36,7 +36,7 @@
     <div class="col-md-12 voyager-relationship-details">
         <a href="{{ route('voyager.bread.delete_relationship', $relationship['id']) }}" class="delete_relationship"><i class="voyager-trash"></i> {{ __('voyager::database.relationship.delete') }}</a>
         <div class="relationship_details_content">
-            <p class="relationship_table_select">{{ str_singular(ucfirst($table)) }}</p>
+            <p class="relationship_table_select">{{ Str::singular(ucfirst($table)) }}</p>
             <select class="relationship_type select2" name="relationship_type_{{ $relationship['field'] }}">
                 <option value="hasOne" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasOne'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_one') }}</option>
                 <option value="hasMany" @if(isset($relationshipDetails->type) && $relationshipDetails->type == 'hasMany'){{ 'selected="selected"' }}@endif>{{ __('voyager::database.relationship.has_many') }}</option>
@@ -52,7 +52,7 @@
         </div>
             <div class="relationshipField">
                 <div class="relationship_details_content margin_top belongsTo @if($relationshipDetails->type == 'belongsTo'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ str_singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span>{{ Str::singular(ucfirst($table)) }}</span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span class="label_table_name"></span>?</label>
                     <select name="relationship_column_belongs_to_{{ $relationship['field'] }}" class="new_relationship_field select2">
                         @foreach($fieldOptions as $data)
                             <option value="{{ $data['field'] }}" @if($relationshipDetails->column == $data['field']){{ 'selected="selected"' }}@endif>{{ $data['field'] }}</option>
@@ -61,7 +61,7 @@
                 </div>
 
                 <div class="relationship_details_content margin_top hasOneMany @if($relationshipDetails->type == 'hasOne' || $relationshipDetails->type == 'hasMany'){{ 'flexed' }}@endif">
-                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ str_singular(ucfirst($table)) }}</span>?</label>
+                    <label>{{ __('voyager::database.relationship.which_column_from') }} <span class="label_table_name"></span> {{ __('voyager::database.relationship.is_used_to_reference') }} <span>{{ Str::singular(ucfirst($table)) }}</span>?</label>
                     <select name="relationship_column_{{ $relationship['field'] }}" class="new_relationship_field select2 rowDrop" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="{{ $relationshipDetails->column }}">
                     </select>
                 </div>
@@ -70,7 +70,7 @@
             <label>{{ __('voyager::database.relationship.pivot_table') }}:</label>
             <select name="relationship_pivot_table_{{ $relationship['field'] }}" class="select2">
                 @foreach($tables as $tbl)
-                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ str_singular(ucfirst($tbl)) }}</option>
+                    <option value="{{ $tbl }}" @if(isset($relationshipDetails->pivot_table) && $relationshipDetails->pivot_table == $tbl){{ 'selected="selected"' }}@endif>{{ Str::singular(ucfirst($tbl)) }}</option>
                 @endforeach
             </select>
         </div>

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Str;
 use TCG\Voyager\Events\Routing;
 use TCG\Voyager\Events\RoutingAdmin;
 use TCG\Voyager\Events\RoutingAdminAfter;
@@ -37,7 +38,7 @@ Route::group(['as' => 'voyager.'], function () {
         try {
             foreach (Voyager::model('DataType')::all() as $dataType) {
                 $breadController = $dataType->controller
-                                 ? str_start($dataType->controller, '\\')
+                                 ? Str::start($dataType->controller, '\\')
                                  : $namespacePrefix.'VoyagerBaseController';
 
                 Route::get($dataType->slug.'/order', $breadController.'@order')->name($dataType->slug.'.order');

--- a/src/FormFields/MediaPickerHandler.php
+++ b/src/FormFields/MediaPickerHandler.php
@@ -27,14 +27,14 @@ class MediaPickerHandler extends AbstractHandler
 
         if (isset($options->base_path)) {
             $options->base_path = str_replace('{uid}', \Auth::user()->getKey(), $options->base_path);
-            if (str_contains($options->base_path, '{date:')) {
+            if (Str::contains($options->base_path, '{date:')) {
                 $options->base_path = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                     return \Carbon\Carbon::now()->format($date[1]);
                 }, $options->base_path);
             }
-            if (str_contains($options->base_path, '{random:')) {
+            if (Str::contains($options->base_path, '{random:')) {
                 $options->base_path = preg_replace_callback('/\{random:([0-9]+)\}/', function ($random) {
-                    return str_random($random[1]);
+                    return Str::random($random[1]);
                 }, $options->base_path);
             }
             if (!$dataTypeContent->getKey()) {

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -26,7 +26,7 @@ if (!function_exists('get_file_name')) {
     {
         preg_match('/(_)([0-9])+$/', $name, $matches);
         if (count($matches) == 3) {
-            return str_replace_last($matches[0], '', $name).'_'.(intval($matches[2]) + 1);
+            return Str::replaceLast($matches[0], '', $name).'_'.(intval($matches[2]) + 1);
         } else {
             return $name.'_1';
         }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -26,7 +26,7 @@ if (!function_exists('get_file_name')) {
     {
         preg_match('/(_)([0-9])+$/', $name, $matches);
         if (count($matches) == 3) {
-            return Str::replaceLast($matches[0], '', $name).'_'.(intval($matches[2]) + 1);
+            return Illuminate\Support\Str::replaceLast($matches[0], '', $name).'_'.(intval($matches[2]) + 1);
         } else {
             return $name.'_1';
         }

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -215,7 +215,7 @@ class VoyagerBreadController extends Controller
         return collect($reflection->getMethods())->filter(function ($method) {
             return starts_with($method->name, 'scope');
         })->whereNotIn('name', ['scopeWithTranslations', 'scopeWithTranslation', 'scopeWhereTranslation'])->transform(function ($method) {
-            return lcfirst(str_replace_first('scope', '', $method->name));
+            return lcfirst(Str::replaceFirst('scope', '', $method->name));
         });
     }
 
@@ -319,7 +319,7 @@ class VoyagerBreadController extends Controller
 
         $dataType = Voyager::model('DataType')->find($request->data_type_id);
 
-        $field = str_singular($dataType->name).'_'.$request->relationship_type.'_'.str_singular($request->relationship_table).'_relationship';
+        $field = Str::singular($dataType->name).'_'.$request->relationship_type.'_'.Str::singular($request->relationship_table).'_relationship';
 
         $relationshipFieldOriginal = $relationshipField = strtolower($field);
 

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Http\Controllers;
 
 use Exception;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Facades\Image;
@@ -102,7 +103,7 @@ class VoyagerMediaController extends Controller
         // Check permission
         $this->authorize('browse_media');
 
-        $path = str_replace('//', '/', str_finish($request->path, '/'));
+        $path = str_replace('//', '/', Str::finish($request->path, '/'));
         $success = true;
         $error = '';
 
@@ -126,13 +127,13 @@ class VoyagerMediaController extends Controller
     {
         // Check permission
         $this->authorize('browse_media');
-        $path = str_replace('//', '/', str_finish($request->path, '/'));
-        $dest = str_replace('//', '/', str_finish($request->destination, '/'));
+        $path = str_replace('//', '/', Str::finish($request->path, '/'));
+        $dest = str_replace('//', '/', Str::finish($request->destination, '/'));
         if (strpos($dest, '/../') !== false) {
             $dest = substr($path, 0, -1);
             $dest = substr($dest, 0, strripos($dest, '/') + 1);
         }
-        $dest = str_replace('//', '/', str_finish($dest, '/'));
+        $dest = str_replace('//', '/', Str::finish($dest, '/'));
 
         $success = true;
         $error = '';
@@ -190,7 +191,7 @@ class VoyagerMediaController extends Controller
         $this->authorize('browse_media');
 
         $extension = $request->file->getClientOriginalExtension();
-        $name = str_replace_last('.'.$extension, '', $request->file->getClientOriginalName());
+        $name = Str::replaceLast('.'.$extension, '', $request->file->getClientOriginalName());
 
         try {
             $realPath = Storage::disk($this->filesystem)->getDriver()->getAdapter()->getPathPrefix();
@@ -201,19 +202,19 @@ class VoyagerMediaController extends Controller
             }
 
             if (!$request->has('filename') || $request->get('filename') == 'null') {
-                while (Storage::disk($this->filesystem)->exists(str_finish($request->upload_path, '/').$name.'.'.$extension, $this->filesystem)) {
+                while (Storage::disk($this->filesystem)->exists(Str::finish($request->upload_path, '/').$name.'.'.$extension, $this->filesystem)) {
                     $name = get_file_name($name);
                 }
             } else {
                 $name = str_replace('{uid}', \Auth::user()->getKey(), $request->get('filename'));
-                if (str_contains($name, '{date:')) {
+                if (Str::contains($name, '{date:')) {
                     $name = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                         return \Carbon\Carbon::now()->format($date[1]);
                     }, $name);
                 }
-                if (str_contains($name, '{random:')) {
+                if (Str::contains($name, '{random:')) {
                     $name = preg_replace_callback('/\{random:([0-9]+)\}/', function ($random) {
-                        return str_random($random[1]);
+                        return Str::random($random[1]);
                     }, $name);
                 }
                 $name .= '.'.$extension;

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use TCG\Voyager\Facades\Voyager;
 
 class VoyagerMenuController extends Controller
@@ -122,7 +123,7 @@ class VoyagerMenuController extends Controller
 
     protected function prepareParameters($parameters)
     {
-        switch (array_get($parameters, 'type')) {
+        switch (Arr::get($parameters, 'type')) {
             case 'route':
                 $parameters['url'] = null;
                 break;

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Storage;
 use TCG\Voyager\Facades\Voyager;
 
@@ -46,7 +47,7 @@ class VoyagerSettingsController extends Controller
         // Check permission
         $this->authorize('add', Voyager::model('Setting'));
 
-        $key = implode('.', [str_slug($request->input('group')), $request->input('key')]);
+        $key = implode('.', [Str::slug($request->input('group')), $request->input('key')]);
         $key_check = Voyager::model('Setting')->where('key', $key)->get()->count();
 
         if ($key_check > 0) {
@@ -101,10 +102,10 @@ class VoyagerSettingsController extends Controller
                 continue;
             }
 
-            $key = preg_replace('/^'.str_slug($setting->group).'./i', '', $setting->key);
+            $key = preg_replace('/^'.Str::slug($setting->group).'./i', '', $setting->key);
 
             $setting->group = $request->input(str_replace('.', '_', $setting->key).'_group');
-            $setting->key = implode('.', [str_slug($setting->group), $key]);
+            $setting->key = implode('.', [Str::slug($setting->group), $key]);
             $setting->value = $content;
             $setting->save();
         }

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use TCG\Voyager\Database\Schema\SchemaManager;
 use TCG\Voyager\Facades\Voyager;
@@ -96,7 +97,7 @@ class DataType extends Model
             if ($this->fill($requestData)->save()) {
                 $fields = $this->fields((strlen($this->model_name) != 0)
                     ? app($this->model_name)->getTable()
-                    : array_get($requestData, 'name')
+                    : Arr::get($requestData, 'name')
                 );
 
                 $requestData = $this->getRelationships($requestData, $fields);

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Events\MenuDisplay;
 use TCG\Voyager\Facades\Voyager;
@@ -105,7 +106,7 @@ class Menu extends Model
             if (url($item->href) == url()->current() && $item->href != '') {
                 // The current URL is exactly the URL of the menu-item
                 $item->active = true;
-            } elseif (starts_with(url()->current(), str_finish(url($item->href), '/'))) {
+            } elseif (starts_with(url()->current(), Str::finish(url($item->href), '/'))) {
                 // The current URL is "below" the menu-item URL. For example "admin/posts/1/edit" => "admin/posts"
                 $item->active = true;
             }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Events\MenuDisplay;
@@ -40,7 +41,7 @@ class Menu extends Model
     public static function display($menuName, $type = null, array $options = [])
     {
         // GET THE MENU - sort collection in blade
-        $menu = \Cache::remember('voyager_menu_'.$menuName, \Carbon::now()->addDays(30), function () use ($menuName) {
+        $menu = \Cache::remember('voyager_menu_'.$menuName, Carbon::now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
             ->with(['parent_items.children' => function ($q) {
                 $q->orderBy('order');

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -40,7 +40,7 @@ class Menu extends Model
     public static function display($menuName, $type = null, array $options = [])
     {
         // GET THE MENU - sort collection in blade
-        $menu = \Cache::remember('voyager_menu_'.$menuName, now()->addDays(30), function () use ($menuName) {
+        $menu = \Cache::remember('voyager_menu_'.$menuName, \Carbon::now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
             ->with(['parent_items.children' => function ($q) {
                 $q->orderBy('order');

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -40,7 +40,7 @@ class Menu extends Model
     public static function display($menuName, $type = null, array $options = [])
     {
         // GET THE MENU - sort collection in blade
-        $menu = \Cache::remember('voyager_menu_'.$menuName, (60 * 24 * 30), function () use ($menuName) {
+        $menu = \Cache::remember('voyager_menu_'.$menuName, now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
             ->with(['parent_items.children' => function ($q) {
                 $q->orderBy('order');

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -3,7 +3,6 @@
 namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Events\MenuDisplay;
@@ -41,7 +40,7 @@ class Menu extends Model
     public static function display($menuName, $type = null, array $options = [])
     {
         // GET THE MENU - sort collection in blade
-        $menu = \Cache::remember('voyager_menu_'.$menuName, Carbon::now()->addDays(30), function () use ($menuName) {
+        $menu = \Cache::remember('voyager_menu_'.$menuName, \Carbon\Carbon::now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
             ->with(['parent_items.children' => function ($q) {
                 $q->orderBy('order');

--- a/src/Traits/Resizable.php
+++ b/src/Traits/Resizable.php
@@ -2,6 +2,8 @@
 
 namespace TCG\Voyager\Traits;
 
+use Illuminate\Support\Str;
+
 trait Resizable
 {
     /**
@@ -39,7 +41,7 @@ trait Resizable
         $ext = pathinfo($image, PATHINFO_EXTENSION);
 
         // We remove extension from file name so we can append thumbnail type
-        $name = str_replace_last('.'.$ext, '', $image);
+        $name = Str::replaceLast('.'.$ext, '', $image);
 
         // We merge original name + type + extension
         return $name.'-'.$type.'.'.$ext;

--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -6,6 +6,7 @@ use Arrilot\Widgets\Facade as Widget;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use TCG\Voyager\Actions\DeleteAction;
@@ -102,7 +103,7 @@ class Voyager
 
     public function view($name, array $parameters = [])
     {
-        foreach (array_get($this->viewLoadingEvents, $name, []) as $event) {
+        foreach (Arr::get($this->viewLoadingEvents, $name, []) as $event) {
             $event($name, $parameters);
         }
 

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
@@ -161,7 +162,7 @@ class VoyagerServiceProvider extends ServiceProvider
         } else {
             $currentRouteAction = null;
         }
-        $routeName = is_array($currentRouteAction) ? array_get($currentRouteAction, 'as') : null;
+        $routeName = is_array($currentRouteAction) ? Arr::get($currentRouteAction, 'as') : null;
 
         if ($routeName != 'voyager.dashboard') {
             return;

--- a/tests/Models/PageTest.php
+++ b/tests/Models/PageTest.php
@@ -2,6 +2,7 @@
 
 namespace TCG\Voyager\Tests;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Models\Page;
 
@@ -51,9 +52,9 @@ class PageTest extends TestCase
             'meta_keywords'    => 'Test Meta Keywords',
         ];
 
-        $inactive = (new Page($data + ['slug' => str_random(8), 'status' => Page::STATUS_INACTIVE]));
+        $inactive = (new Page($data + ['slug' => Str::random(8), 'status' => Page::STATUS_INACTIVE]));
         $inactive->save();
-        $active = (new Page($data + ['slug' => str_random(8), 'status' => Page::STATUS_ACTIVE]));
+        $active = (new Page($data + ['slug' => Str::random(8), 'status' => Page::STATUS_ACTIVE]));
         $active->save();
 
         // Act

--- a/tests/database/factories/UserFactory.php
+++ b/tests/database/factories/UserFactory.php
@@ -10,6 +10,6 @@ $factory->define(\TCG\Voyager\Models\User::class, function (Faker\Generator $fak
             return factory(\TCG\Voyager\Models\Role::class)->create()->id;
         },
         'password'       => $password ?: $password = bcrypt('secret'),
-        'remember_token' => str_random(10),
+        'remember_token' => Illuminate\Support\Str::random(10),
     ];
 });


### PR DESCRIPTION
- Replaced `str_*` and `array_*` helper with the corresponding facades `Str::*` and `Arr::*`
- Had to change the migrations to use `bigint` for everything that points to the user-id (roles and permissions) / Rollback works fine for me now.
- I didn't drop Laravel 5.4 support in this PR as it needs much more changes to our testbench