### PR TITLE
update menu children by setRelation() method

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -120,7 +120,7 @@ class Menu extends Model
             }
 
             if ($item->children->count() > 0) {
-                $item->children = static::processItems($item->children);
+                $item->setRelation('children', static::processItems($item->children));
 
                 if (!$item->children->where('active', true)->isEmpty()) {
                     $item->active = true;


### PR DESCRIPTION
The `$item->children = static::processItems($item->children);` doesn't work.
It still showing the menu item in sidebar, so in this change will use setRelation method instead.
 `$item->setRelation('children', static::processItems($item->children));`