### PR TITLE
Rollback not working when settings table has data

### DIFF
--- a/migrations/2018_03_16_000000_make_settings_value_nullable.php
+++ b/migrations/2018_03_16_000000_make_settings_value_nullable.php
@@ -26,7 +26,7 @@ class MakeSettingsValueNullable extends Migration
     public function down()
     {
         Schema::table('settings', function (Blueprint $table) {
-            $table->text('value')->nullable(false)->change();
+            $table->text('value')->nullable()->change();
         });
     }
 }


### PR DESCRIPTION
I have an error when doing a rollback if the settings table have some data.
```
  Illuminate\Database\QueryException  : SQLSTATE[22004]: Null value not allowed: 1138 Invalid use of NULL value (SQL: ALTER TABLE settings CHANGE value value TEXT NOT NULL COLLATE utf8mb4_unicode_ci)
```