### PR TITLE
JSON details added to relationship fields of BREAD editor and improving relationship field names.

### DIFF
--- a/migrations/2019_03_26_000000_update_data_rows_field_values.php
+++ b/migrations/2019_03_26_000000_update_data_rows_field_values.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use TCG\Voyager\Models\DataRow;
+use TCG\Voyager\Models\DataType;
+use Illuminate\Support\Str;
+
+class UpdateDataRowsFieldValues extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $records = TCG\Voyager\Models\DataRow::where('type','relationship')->get();
+        foreach ($records as $rec) {
+            $dataType = DataType::find($rec->data_type_id);
+            $field = Str::singular($dataType->name).'_'.$rec->details->type.'_'.Str::singular($rec->details->table).'_relationship_'.$rec->details->column;
+            
+            $a = $rec->details;
+            $a->_fallback_field = $rec->field;
+            
+            $rec->details = $a;
+            $rec->field = strtolower($field);
+            $rec->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $records = DataRow::where('type','relationship')->get();
+        foreach ($records as $rec) {
+       
+            if (property_exists($rec->details,'_fallback_field')) {
+                $field = $rec->details->_fallback_field;
+            
+                $a = $rec->details;
+                unset($a->_fallback_field);
+
+                $rec->details = $a;
+                $rec->field = $field;
+    
+                $rec->save();
+            }
+        }
+    }
+}

--- a/migrations/2019_03_26_000000_update_data_rows_field_values.php
+++ b/migrations/2019_03_26_000000_update_data_rows_field_values.php
@@ -1,9 +1,9 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Str;
 use TCG\Voyager\Models\DataRow;
 use TCG\Voyager\Models\DataType;
-use Illuminate\Support\Str;
 
 class UpdateDataRowsFieldValues extends Migration
 {
@@ -14,7 +14,7 @@ class UpdateDataRowsFieldValues extends Migration
      */
     public function up()
     {
-        $records = TCG\Voyager\Models\DataRow::where('type','relationship')->get();
+        $records = DataRow::where('type', 'relationship')->get();
         foreach ($records as $rec) {
             $dataType = DataType::find($rec->data_type_id);
             $field = Str::singular($dataType->name).'_'.$rec->details->type.'_'.Str::singular($rec->details->table).'_relationship_'.$rec->details->column;
@@ -35,10 +35,10 @@ class UpdateDataRowsFieldValues extends Migration
      */
     public function down()
     {
-        $records = DataRow::where('type','relationship')->get();
+        $records = DataRow::where('type', 'relationship')->get();
         foreach ($records as $rec) {
        
-            if (property_exists($rec->details,'_fallback_field')) {
+            if (property_exists($rec->details, '_fallback_field')) {
                 $field = $rec->details->_fallback_field;
             
                 $a = $rec->details;

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -1,4 +1,11 @@
-@php $relationshipDetails = $relationship['details']; @endphp
+@php
+    $relationshipDetails = $relationship['details']; 
+    $adv_details = new \StdClass;
+    foreach (get_object_vars($relationshipDetails) as $key=>$value) {
+        if(!in_array($key,["model", "table", "type", "column", "key", "label", "pivot_table", "pivot", "taggable"])) $adv_details->$key = $value;
+    }
+
+@endphp
 <div class="row row-dd row-dd-relationship">
     <div class="col-xs-2">
         <h4><i class="voyager-heart"></i><strong>{{ $relationship->display_name }}</strong></h4>
@@ -26,6 +33,12 @@
         <input type="text" name="field_display_name_{{ $relationship['field'] }}" class="form-control relationship_display_name" value="{{ $relationship['display_name'] }}">
     </div>
     <div class="col-xs-4">
+        <div style="margin-bottom:20px;">
+            <div class="alert alert-danger validation-error">
+                {{ __('voyager::json.invalid') }}
+            </div>
+            <textarea id="json-input-{{ $relationship['field'] }}" class="resizable-editor" data-editor="json" name="relationship_details_{{ $relationship['field'] }}">{{ json_encode($adv_details) }}</textarea>
+        </div>
         <div class="voyager-relationship-details-btn">
             <i class="voyager-angle-down"></i><i class="voyager-angle-up"></i>
             <span class="open_text">{{ __('voyager::database.relationship.open') }}</span>

--- a/resources/views/users/edit-add.blade.php
+++ b/resources/views/users/edit-add.blade.php
@@ -66,7 +66,7 @@
                                     @php
                                         $dataTypeRows = $dataType->{(isset($dataTypeContent->id) ? 'editRows' : 'addRows' )};
 
-                                        $row     = $dataTypeRows->where('field', 'user_belongsto_role_relationship')->first();
+                                        $row     = $dataTypeRows->where('field', 'user_belongsto_role_relationship_role_id')->first();
                                         $options = $row->details;
                                     @endphp
                                     @include('voyager::formfields.relationship')
@@ -74,7 +74,7 @@
                                 <div class="form-group">
                                     <label for="additional_roles">{{ __('voyager::profile.roles_additional') }}</label>
                                     @php
-                                        $row     = $dataTypeRows->where('field', 'user_belongstomany_role_relationship')->first();
+                                        $row     = $dataTypeRows->where('field', 'user_belongstomany_role_relationship_id')->first();
                                         $options = $row->details;
                                     @endphp
                                     @include('voyager::formfields.relationship')

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -319,7 +319,12 @@ class VoyagerBreadController extends Controller
 
         $dataType = Voyager::model('DataType')->find($request->data_type_id);
 
-        $field = Str::singular($dataType->name).'_'.$request->relationship_type.'_'.Str::singular($request->relationship_table).'_relationship';
+        $relationship_column = $request->relationship_column_belongs_to;
+        if ($request->relationship_type == 'hasOne' || $request->relationship_type == 'hasMany') {
+            $relationship_column = $request->relationship_column;
+        }
+
+        $field = Str::singular($dataType->name).'_'.$request->relationship_type.'_'.Str::singular($request->relationship_table).'_relationship_'.$relationship_column;
 
         $relationshipFieldOriginal = $relationshipField = strtolower($field);
 
@@ -329,7 +334,7 @@ class VoyagerBreadController extends Controller
         while (isset($existingRow->id)) {
             $relationshipField = $relationshipFieldOriginal.'_'.$index;
             $existingRow = Voyager::model('DataRow')->where('field', '=', $relationshipField)->first();
-            $index += 1;
+            $index++;
         }
 
         return $relationshipField;

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -116,6 +116,18 @@ class DataType extends Model
                     $dataRow->display_name = $requestData['field_display_name_'.$field];
                     $dataRow->order = intval($requestData['field_order_'.$field]);
 
+                    $relationship_details = $requestData['relationship_details_'.$field] ?? null;
+                    if ($relationship_details) {
+                        $relationship_details = json_decode($relationship_details);
+                        if (is_object($relationship_details)) {
+                            $dataRowDetails = $dataRow->details;
+                            foreach ($relationship_details as $key=>$value) {
+                                if (!isset($dataRowDetails->$key)) $dataRowDetails->$key = $value;
+                            }
+                            $dataRow->details = $dataRowDetails;
+                        }
+                    }
+
                     if (!$dataRow->save()) {
                         throw new \Exception(__('voyager::database.field_safe_failed', ['field' => $field]));
                     }

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -122,7 +122,9 @@ class DataType extends Model
                         if (is_object($relationship_details)) {
                             $dataRowDetails = $dataRow->details;
                             foreach ($relationship_details as $key=>$value) {
-                                if (!isset($dataRowDetails->$key)) $dataRowDetails->$key = $value;
+                                if (!isset($dataRowDetails->$key)) {
+                                    $dataRowDetails->$key = $value;
+                                }
                             }
                             $dataRow->details = $dataRowDetails;
                         }


### PR DESCRIPTION
Relationship details added to BREAD editor (json field like in all other fields) to set width of field on form or whatever.
Also make field name for relationship more unique and understandable (migration to safe fix\rollback 2019_03_26_000000_update_data_rows_field_values.php included)

no more confusing 
`"tablename_belongsto_user_relationship" and
"tablename_belongsto_user_relationship-1"`
now it
`"tablename_belongsto_user_relationship_user_id"  and
"tablename_belongsto_user_relationship_somecolumn_id"`