### PR TITLE
Fix the route problem after adding/updating BREAD.

### DIFF
--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Http\Controllers;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use ReflectionClass;
@@ -101,6 +102,9 @@ class VoyagerBreadController extends Controller
                 event(new BreadAdded($dataType, $data));
             }
 
+            // Cache route list to add the new slug
+            Artisan:call('optimize');
+            
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
             return redirect()->route('voyager.bread.index')->with($this->alertException($e, 'Saving Failed'));
@@ -168,6 +172,9 @@ class VoyagerBreadController extends Controller
             // Save translations if applied
             $dataType->saveTranslations($translations);
 
+            // Cache route list to add the new slug if applied
+            Artisan:call('optimize');
+                        
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
             return back()->with($this->alertException($e, __('voyager::generic.update_failed')));

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -103,7 +103,7 @@ class VoyagerBreadController extends Controller
             }
 
             // Cache route list to add the new slug
-            Artisan:call('optimize');
+            Artisan::call('optimize');
             
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
@@ -173,7 +173,7 @@ class VoyagerBreadController extends Controller
             $dataType->saveTranslations($translations);
 
             // Cache route list to add the new slug if applied
-            Artisan:call('optimize');
+            Artisan::call('optimize');
                         
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -104,7 +104,7 @@ class VoyagerBreadController extends Controller
 
             // Cache route list to add the new slug
             Artisan::call('optimize');
-            
+
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
             return redirect()->route('voyager.bread.index')->with($this->alertException($e, 'Saving Failed'));
@@ -174,7 +174,7 @@ class VoyagerBreadController extends Controller
 
             // Cache route list to add the new slug if applied
             Artisan::call('optimize');
-                        
+
             return redirect()->route('voyager.bread.index')->with($data);
         } catch (Exception $e) {
             return back()->with($this->alertException($e, __('voyager::generic.update_failed')));


### PR DESCRIPTION
When we add new BREAD the new slug appends to route list. In new Laravel version we have to manually cache the list of routes to have it updated after modifications.

In our case, when we add new BREAD and it's routes append to the route list we have to cache the list again. Because of it we have an exception every time we create new BREAD (update old one slug).

For two cases (store and update) I call here Artisan command to optimize the config files.