### PR TITLE
Fixed issue with saving for multilingual rich text box

### DIFF
--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -94,7 +94,7 @@
              */
             this.transInputs.each(function(i, inp) {
                 var _inp   = $(inp),
-                    inpUsr = _inp.next(_this.settings.editing ? '.form-control' : '');
+                    inpUsr = $(_inp).parent().find(_this.settings.editing ? '.form-control' : '');
 
                 inpUsr.data("inp", _inp);
                 _inp.data("inpUsr", inpUsr);

--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -93,8 +93,13 @@
              * Setup translatable inputs
              */
             this.transInputs.each(function(i, inp) {
-                var _inp   = $(inp),
-                    inpUsr = $(_inp).parent().find(_this.settings.editing ? '.form-control' : '');
+                var _inp   = $(inp)
+                
+                if(_this.element.attr('id') === 'menu_item_modal') {
+                    var inpUsr = _inp.next(_this.settings.editing ? '.form-control' : '');
+                } else {
+                    var inpUsr = $(_inp).parent().find(_this.settings.editing ? '.form-control' : '');
+                }
 
                 inpUsr.data("inp", _inp);
                 _inp.data("inpUsr", inpUsr);


### PR DESCRIPTION
Voyager 1.2.3 have an issue with saving/editing multilingual rich text box.

The root cause of this issue is due to the position of DOM element for rich text box inputs. This changes will fix the issue by first targeting the parents of the "_il8n" element and then search for the input field with the class name "form-control".