### PR TITLE
Update File.php

### DIFF
--- a/src/Http/Controllers/ContentTypes/File.php
+++ b/src/Http/Controllers/ContentTypes/File.php
@@ -14,7 +14,7 @@ class File extends BaseType
     public function handle()
     {
         if (!$this->request->hasFile($this->row->field)) {
-            return json_encode([]);
+            return "{}";
         }
 
         $files = Arr::wrap($this->request->file($this->row->field));

--- a/src/Http/Controllers/ContentTypes/File.php
+++ b/src/Http/Controllers/ContentTypes/File.php
@@ -14,7 +14,7 @@ class File extends BaseType
     public function handle()
     {
         if (!$this->request->hasFile($this->row->field)) {
-            return "{}";
+            return '{}';
         }
 
         $files = Arr::wrap($this->request->file($this->row->field));


### PR DESCRIPTION
When no file uploaded for file type, viewing or editing resulted in invalid download link.
Returning json_encode([]) returns "[]" instead of the intended empty JSON object, so file.blade.php does not properly interpret the fact that there is no file.