### PR TITLE
Update file.blade.php

### DIFF
--- a/resources/views/formfields/file.blade.php
+++ b/resources/views/formfields/file.blade.php
@@ -1,4 +1,4 @@
-@if(isset($dataTypeContent->{$row->field}))
+@if(isset($dataTypeContent->{$row->field}) && $dataTypeContent->{$row->field} != '[]')
     @if(json_decode($dataTypeContent->{$row->field}))
         @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
           <div data-field-name="{{ $row->field }}">


### PR DESCRIPTION
When no file uploaded for file type, viewing or editing resulted in invalid download link.
json_decode of "[]" returns false, so file.blade.php does not properly interpret the fact that there is no file.