### PR TITLE
fix #4072, #4152

### DIFF
--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -94,7 +94,7 @@
              */
             this.transInputs.each(function(i, inp) {
                 var _inp   = $(inp),
-                    inpUsr = _inp.next(_this.settings.editing ? '.form-control' : '');
+                    inpUsr = _inp.nextAll(_this.settings.editing ? '.form-control' : '');
 
                 inpUsr.data("inp", _inp);
                 _inp.data("inpUsr", inpUsr);


### PR DESCRIPTION
The error results from the fact that we are looking for an immediately next element. But for RichBox, a magic editor appends between our field and hidden input.

Check please. It's worked, so easy.

---

after fix steps:
**re-compile voyager assets**
```
cd vendor/tcg/voyager
npm run prod
```

**clear laravel cache**
```
php artisan cache:clear
```