### PR TITLE
Fix the row deletion if the field json is null

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -486,7 +486,7 @@ class VoyagerBaseController extends Controller
 
         // Delete Files
         foreach ($dataType->deleteRows->where('type', 'file') as $row) {
-            if (isset($data->{$row->field})) {
+            if (isset($data->{$row->field}) AND !is_null(json_decode($data->{$row->field}))) {
                 foreach (json_decode($data->{$row->field}) as $file) {
                     $this->deleteFileIfExists($file->download_link);
                 }


### PR DESCRIPTION
When the file field contains a malformed json, It will throw an exception, so we need to check if the json_decode return is not null before supplying a null as a foreach parameter. 