### PR TITLE
Fix S3 disk found string length of 0

### DIFF
--- a/resources/views/media/manager.blade.php
+++ b/resources/views/media/manager.blade.php
@@ -6,7 +6,7 @@
                 <div class="file_link selected" aria-hidden="true" data-toggle="tooltip" data-placement="auto" :title="file">
                     <div class="link_icon">
                         <template v-if="fileIs(file, 'image')">
-                            <div class="img_icon" :style="imgIcon('{{ Storage::disk(config('voyager.storage.disk'))->url('') }}'+file)"></div>
+                            <div class="img_icon" :style="imgIcon('{{ Storage::disk(config('voyager.storage.disk'))->url('/') }}'+file)"></div>
                         </template>
                         <template v-else-if="fileIs(file, 'video')">
                             <i class="icon voyager-video"></i>


### PR DESCRIPTION
When using S3 as the default filesystem driver, you'll get this error when accessing the dashboard.

Found 1 error while validating the input provided for the GetObject operation: [Key] expected string length to be >= 1, but found string length of 0 (View: /public_html/main/vendor/tcg/voyager/resources/views/media/manager.blade.php)

The error can be found in `/voyager/resources/views/media/manager.blade.php` on line 9.
```
 <div class="img_icon" :style="imgIcon('{{ Storage::disk(config('voyager.storage.disk'))->url('') }}'+file)"></div>
```
Adding a "/" to the `url` method solves this error. I opened an issue #4169 on this.