### PR TITLE
Media picker order fix

### DIFF
--- a/docs/core-concepts/bread-builder.md
+++ b/docs/core-concepts/bread-builder.md
@@ -150,6 +150,7 @@ These are standard attributes for number input field, default value for **step**
 {
     "max": 10,
     "min": 0,
+    "expanded": false,
     "show_folders": true,
     "show_toolbar": true,
     "allow_upload": true,
@@ -178,6 +179,7 @@ You can customize the behaviour with the following options:
 - `delete_files` boolean value if the files should be deleted when the entry is deleted. This will also delete the file if it is used in other entries!
 - `max` the maximum of files a user can select
 - `min` the minimum of files that are required
+- `expanded` should the media-picker be expanded by default
 - `show_folders` show subfolders or not
 - `show_toolbar` hide the whole toolbar
 - `allow_upload` allow users to upload new files

--- a/resources/views/formfields/media_picker.blade.php
+++ b/resources/views/formfields/media_picker.blade.php
@@ -17,7 +17,7 @@
                 :allow-crop="{{ var_export($options->allow_crop ?? true, true) }}"
                 :allowed-types="{{ isset($options->allowed) && is_array($options->allowed) ? json_encode($options->allowed) : '[]' }}"
                 :pre-select="false"
-                :expanded="false"
+                :expanded="{{ var_export($options->expanded ?? false, true) }}"
                 :show-expand-button="true"
                 :element="'input[name=&quot;{{ $row->field }}&quot;]'"
                 :details="{{ json_encode($options ?? []) }}"

--- a/resources/views/media/manager.blade.php
+++ b/resources/views/media/manager.blade.php
@@ -1,6 +1,6 @@
 @section('media-manager')
 <div>
-    <div v-if="hidden_element" class="dd">
+    <div v-if="hidden_element" :id="'dd_'+this._uid" class="dd">
         <ol id="files" class="dd-list">
             <li v-for="file in getSelectedFiles()" class="dd-item" :data-url="file">
                 <div class="file_link selected" aria-hidden="true" data-toggle="tooltip" data-placement="auto" :title="file">
@@ -605,6 +605,7 @@
                         } else {
                             content.push(file.relative_path);
                             this.hidden_element.value = JSON.stringify(content);
+                            this.$forceUpdate();
                         }
                     }
                 }
@@ -914,16 +915,15 @@
                 });
 
                 //Nestable
-                $('.dd').nestable({
+                $('#dd_'+vm._uid).nestable({
                     maxDepth: 1,
                     handleClass: 'file_link',
                     collapseBtnHTML: '',
                     expandBtnHTML: '',
-                    emptyClass : '',
                     callback: function(l, e) {
                         if (vm.allowMultiSelect) {
                             var new_content = [];
-                            var object = $('.dd').nestable('serialize');
+                            var object = $('#dd_'+vm._uid).nestable('serialize');
                             for (var key in object) {
                                 new_content.push(object[key].url);
                             }
@@ -943,3 +943,11 @@
         },
     });
 </script>
+<style>
+.dd-placeholder {
+    flex: 1;
+    width: 100%;
+    min-width: 200px;
+    max-width: 250px;
+}
+</style>


### PR DESCRIPTION
When having multiple media-picker on the same page, the ordering wasn't working properly as the drag-functionaility was identified by the ID which was the same for all media-picker.
Overall improved the ordering/selection of files.

Also lets user expand the media-picker by default by setting `expanded` to true in the options.

Fixes #4133