### PR TITLE
Settings not using options

### DIFF
--- a/publishable/lang/de/settings.php
+++ b/publishable/lang/de/settings.php
@@ -6,7 +6,7 @@ return [
     'new'                  => 'Neue Einstellung',
     'help_name'            => 'Einstellungs-Name z.B. Admin Titel',
     'help_key'             => 'Einstellungs-Schlüssel z.B. title',
-    'help_option'          => '(optional, betrifft lediglich bestimmte Typen wie Dropdown Box oder Radio Button)',
+    'help_option'          => '(optional, die selben Optionen wie für das entsprechende Formfield können benutzt werden)',
     'add_new'              => 'Neue Einstellung hinzufügen',
     'delete_question'      => 'Wollen Sie die Einstellung :setting wirklich löschen?',
     'delete_confirm'       => 'Ja, diese Einstellung löschen',

--- a/publishable/lang/en/settings.php
+++ b/publishable/lang/en/settings.php
@@ -6,7 +6,7 @@ return [
     'new'                  => 'New Setting',
     'help_name'            => 'Setting name ex: Admin Title',
     'help_key'             => 'Setting key ex: admin_title',
-    'help_option'          => '(optional, only applies to certain types like dropdown box or radio button)',
+    'help_option'          => '(optional, the same options as for the corresponding formfield apply)',
     'add_new'              => 'Add New Setting',
     'delete_question'      => 'Are you sure you want to delete the :setting Setting?',
     'delete_confirm'       => 'Yes, Delete This Setting',

--- a/src/Http/Controllers/VoyagerSettingsController.php
+++ b/src/Http/Controllers/VoyagerSettingsController.php
@@ -90,9 +90,8 @@ class VoyagerSettingsController extends Controller
             $content = $this->getContentBasedOnType($request, 'settings', (object) [
                 'type'    => $setting->type,
                 'field'   => str_replace('.', '_', $setting->key),
-                'details' => $setting->details,
                 'group'   => $setting->group,
-            ]);
+            ], $setting->details);
 
             if ($setting->type == 'image' && $content == null) {
                 continue;


### PR DESCRIPTION
In https://github.com/the-control-group/voyager/pull/2454 the `getContentBasedOnType` signature was changed to have a fourth argument `$options` which the settings did not pass.
This problem was worked-around in https://github.com/the-control-group/voyager/pull/2725.
This PR properly passes the defined options from the settings to the method.

Fixes https://github.com/the-control-group/voyager/issues/4105