### PR TITLE
Fix menu items display order

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -41,7 +41,8 @@ class MenuItem extends Model
     public function children()
     {
         return $this->hasMany(Voyager::modelClass('MenuItem'), 'parent_id')
-            ->with('children');
+            ->with('children')
+            ->orderBy('order');
     }
 
     public function menu()


### PR DESCRIPTION
#### Menu items display order
In a given nested menu
Child menu items are not ordered by "order" column.