### PR TITLE
Fix: Custom guard usage inside postLogin & authorize

### DIFF
--- a/src/FormFields/MediaPickerHandler.php
+++ b/src/FormFields/MediaPickerHandler.php
@@ -26,7 +26,7 @@ class MediaPickerHandler extends AbstractHandler
         }
 
         if (isset($options->base_path)) {
-            $options->base_path = str_replace('{uid}', \Auth::user()->getKey(), $options->base_path);
+            $options->base_path = str_replace('{uid}', app('VoyagerAuth')->user()->getKey(), $options->base_path);
             if (Str::contains($options->base_path, '{date:')) {
                 $options->base_path = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                     return \Carbon\Carbon::now()->format($date[1]);

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -280,11 +280,12 @@ abstract class Controller extends BaseController
     /**
      * Authorize a given action for the current user.
      *
-     * @param  mixed  $ability
-     * @param  mixed|array  $arguments
-     * @return \Illuminate\Auth\Access\Response
+     * @param mixed       $ability
+     * @param mixed|array $arguments
      *
      * @throws \Illuminate\Auth\Access\AuthorizationException
+     *
+     * @return \Illuminate\Auth\Access\Response
      */
     public function authorize($ability, $arguments = [])
     {

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -276,4 +276,20 @@ abstract class Controller extends BaseController
             return !empty($value->details->validation->rule);
         });
     }
+
+    /**
+     * Authorize a given action for the current user.
+     *
+     * @param  mixed  $ability
+     * @param  mixed|array  $arguments
+     * @return \Illuminate\Auth\Access\Response
+     *
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function authorize($ability, $arguments = [])
+    {
+        $user = app('VoyagerAuth')->user();
+
+        return $this->authorizeForUser($user, $ability, $arguments);
+    }
 }

--- a/src/Http/Controllers/VoyagerAuthController.php
+++ b/src/Http/Controllers/VoyagerAuthController.php
@@ -34,7 +34,7 @@ class VoyagerAuthController extends Controller
 
         $credentials = $this->credentials($request);
 
-        if ($this->guard()->attempt($credentials, $request->has('remember'))) {
+        if (app('VoyagerAuth')->attempt($credentials, $request->has('remember'))) {
             return $this->sendLoginResponse($request);
         }
 

--- a/src/Http/Controllers/VoyagerAuthController.php
+++ b/src/Http/Controllers/VoyagerAuthController.php
@@ -12,7 +12,7 @@ class VoyagerAuthController extends Controller
 
     public function login()
     {
-        if (app('VoyagerAuth')->user()) {
+        if ($this->guard()->user()) {
             return redirect()->route('voyager.dashboard');
         }
 
@@ -34,7 +34,7 @@ class VoyagerAuthController extends Controller
 
         $credentials = $this->credentials($request);
 
-        if (app('VoyagerAuth')->attempt($credentials, $request->has('remember'))) {
+        if ($this->guard()->attempt($credentials, $request->has('remember'))) {
             return $this->sendLoginResponse($request);
         }
 
@@ -52,5 +52,15 @@ class VoyagerAuthController extends Controller
     public function redirectTo()
     {
         return config('voyager.user.redirect', route('voyager.dashboard'));
+    }
+
+    /**
+     * Get the guard to be used during authentication.
+     *
+     * @return \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected function guard()
+    {
+        return app('VoyagerAuth');
     }
 }

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -232,7 +232,7 @@ class VoyagerMediaController extends Controller
                     $name = get_file_name($name);
                 }
             } else {
-                $name = str_replace('{uid}', \Auth::user()->getKey(), $request->get('filename'));
+                $name = str_replace('{uid}', app('VoyagerAuth')->user()->getKey(), $request->get('filename'));
                 if (Str::contains($name, '{date:')) {
                     $name = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                         return \Carbon\Carbon::now()->format($date[1]);

--- a/tests/CustomGuardTest.php
+++ b/tests/CustomGuardTest.php
@@ -4,17 +4,15 @@ namespace TCG\Voyager\Tests;
 
 use Auth;
 use Illuminate\Contracts\Auth\StatefulGuard;
-use TCG\Voyager\Http\Controllers\VoyagerAuthController;
-use TCG\Voyager\Http\Middleware\VoyagerAdminMiddleware;
-use TCG\Voyager\Models\User;
-use TCG\Voyager\Tests\TestCase;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use TCG\Voyager\Http\Middleware\VoyagerAdminMiddleware;
+use TCG\Voyager\Models\User;
 
 class CustomGuardTest extends TestCase
 {
     /**
-     * Admin middleware uses custom guard
+     * Admin middleware uses custom guard.
      *
      * This test will make sure that the VoyagerAdminMiddleware uses
      * the custom guard.
@@ -24,9 +22,9 @@ class CustomGuardTest extends TestCase
         $this->useAuthorizedCustomGuard();
 
         $middleware = new VoyagerAdminMiddleware();
-        $response = new Response;
+        $response = new Response();
 
-        $actualResponse = $middleware->handle(new Request, function() use ($response) {
+        $actualResponse = $middleware->handle(new Request(), function () use ($response) {
             return $response;
         });
 
@@ -36,7 +34,7 @@ class CustomGuardTest extends TestCase
     }
 
     /**
-     * Voyager postLogin uses custom guard
+     * Voyager postLogin uses custom guard.
      *
      * This test will make sure that the postLogin uses custom guard
      * for authorizing users.
@@ -44,7 +42,7 @@ class CustomGuardTest extends TestCase
     public function testVoyagerPostLoginUsesCustomGuard()
     {
         $loginData = [
-            'email' => 'voyager@voyager.com',
+            'email'    => 'voyager@voyager.com',
             'password' => 'voyager',
         ];
 
@@ -60,7 +58,7 @@ class CustomGuardTest extends TestCase
 
         $guard->method('attempt')
             ->will($this->returnValueMap([
-                [$loginData, false, true]
+                [$loginData, false, true],
             ]));
 
         $this->app->instance('VoyagerAuth', $guard);
@@ -73,7 +71,7 @@ class CustomGuardTest extends TestCase
     }
 
     /**
-     * Voyager controllers use custom guard
+     * Voyager controllers use custom guard.
      *
      * This test will make sure that controllers internal authorize()
      * function uses the custom guard.
@@ -89,7 +87,7 @@ class CustomGuardTest extends TestCase
     }
 
     /**
-     * Default guard is used when custom is not defined
+     * Default guard is used when custom is not defined.
      *
      * This test will make sure that VoyagerAuth defaults to the applications
      * default guard when no custom guard is defined.
@@ -140,4 +138,3 @@ class CustomGuardTest extends TestCase
         return $guard;
     }
 }
-

--- a/tests/CustomGuardTest.php
+++ b/tests/CustomGuardTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace TCG\Voyager\Tests;
+
+use Auth;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use TCG\Voyager\Http\Controllers\VoyagerAuthController;
+use TCG\Voyager\Http\Middleware\VoyagerAdminMiddleware;
+use TCG\Voyager\Models\User;
+use TCG\Voyager\Tests\TestCase;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class CustomGuardTest extends TestCase
+{
+    /**
+     * Admin middleware uses custom guard
+     *
+     * This test will make sure that the VoyagerAdminMiddleware uses
+     * the custom guard.
+     */
+    public function testAdminMiddlewareUsesCustomGuard()
+    {
+        $this->useAuthorizedCustomGuard();
+
+        $middleware = new VoyagerAdminMiddleware();
+        $response = new Response;
+
+        $actualResponse = $middleware->handle(new Request, function() use ($response) {
+            return $response;
+        });
+
+        // Correct guard usage will return our $response.
+        // Incorrect guard usage will redirect us to login
+        $this->assertSame($actualResponse, $response);
+    }
+
+    /**
+     * Voyager postLogin uses custom guard
+     *
+     * This test will make sure that the postLogin uses custom guard
+     * for authorizing users.
+     */
+    public function testVoyagerPostLoginUsesCustomGuard()
+    {
+        $loginData = [
+            'email' => 'voyager@voyager.com',
+            'password' => 'voyager',
+        ];
+
+        $guard = $this->getMockBuilder(StatefulGuard::class)
+            ->setMethods(['guest', 'user', 'attempt'])
+            ->getMockForAbstractClass();
+
+        $guard->method('guest')
+            ->will($this->returnValue(true));
+
+        $guard->method('user')
+            ->will($this->returnValue(null));
+
+        $guard->method('attempt')
+            ->will($this->returnValueMap([
+                [$loginData, false, true]
+            ]));
+
+        $this->app->instance('VoyagerAuth', $guard);
+
+        $response = $this->json('POST', route('voyager.postlogin'), $loginData);
+
+        // Correct guard usage will redirect us to the dashboard.
+        // Incorrect guard, and failed login will redirect us to login.
+        $response->assertRedirectedTo(route('voyager.dashboard'));
+    }
+
+    /**
+     * Voyager controllers use custom guard
+     *
+     * This test will make sure that controllers internal authorize()
+     * function uses the custom guard.
+     */
+    public function testVoyagerControllersUseCustomGuard()
+    {
+        $this->useAuthorizedCustomGuard();
+
+        $response = $this->action('GET', 'TCG\Voyager\Http\Controllers\VoyagerBaseController@index');
+
+        // Incorrect guard usage will redirect to login
+        $this->assertResponseOk($response);
+    }
+
+    /**
+     * Default guard is used when custom is not defined
+     *
+     * This test will make sure that VoyagerAuth defaults to the applications
+     * default guard when no custom guard is defined.
+     */
+    public function testDefaultGuardIsUsedWhenCustomIsNotDefined()
+    {
+        $this->assertSame($this->app->get('VoyagerAuth')->guard(), Auth::guard());
+    }
+
+    /**
+     * Return mock user where hasPermission always returns true.
+     */
+    protected function getMockUserWithAllPermissions()
+    {
+        $user = $this->getMockBuilder(User::class)
+            ->setMethods(['hasPermission'])
+            ->getMock();
+
+        $user->method('hasPermission')
+            ->will($this->returnValue(true));
+
+        return $user;
+    }
+
+    /**
+     * Sets the application to use custom guard which is authenticated
+     * with an mocked admin user.
+     */
+    protected function useAuthorizedCustomGuard()
+    {
+        $user = $this->getMockUserWithAllPermissions();
+
+        $guard = $this->getMockBuilder(StatefulGuard::class)
+            ->setMethods(['guest', 'check', 'user'])
+            ->getMockForAbstractClass();
+
+        $guard->method('guest')
+            ->will($this->returnValue(false));
+
+        $guard->method('check')
+            ->will($this->returnValue(false));
+
+        $guard->method('user')
+            ->will($this->returnValue($user));
+
+        $this->app->instance('VoyagerAuth', $guard);
+
+        return $guard;
+    }
+}
+


### PR DESCRIPTION
`$this->guard()` still defaults to the project default guard through the AuthenticatesUsers trait but instead it should use the guard binded to `VoyagerAuth`.