### PR TITLE
Ensure enum column types do not prevent editing tables in mysql datab…

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -8,11 +8,12 @@ use TCG\Voyager\Database\Types\Type;
 
 abstract class Column
 {
-    public static function make(array $column)
+    public static function make(array $column, string $tableName = null)
     {
         $name = Identifier::validate($column['name'], 'Column');
         $type = $column['type'];
         $type = ($type instanceof DoctrineType) ? $type : DoctrineType::getType(trim($type['name']));
+        $type->tableName = $tableName;
 
         $options = array_diff_key($column, ['name' => $name, 'type' => $type]);
 

--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -8,11 +8,12 @@ use TCG\Voyager\Database\Types\Type;
 
 abstract class Column
 {
-    public static function make(array $column)
+    public static function make(array $column , string $tableName = null)
     {
         $name = Identifier::validate($column['name'], 'Column');
         $type = $column['type'];
         $type = ($type instanceof DoctrineType) ? $type : DoctrineType::getType(trim($type['name']));
+        $type->tableName = $tableName;
 
         $options = array_diff_key($column, ['name' => $name, 'type' => $type]);
 

--- a/src/Database/Schema/Table.php
+++ b/src/Database/Schema/Table.php
@@ -17,7 +17,7 @@ class Table extends DoctrineTable
 
         $columns = [];
         foreach ($table['columns'] as $columnArr) {
-            $column = Column::make($columnArr);
+            $column = Column::make($columnArr, $table['name']);
             $columns[$column->getName()] = $column;
         }
 

--- a/src/Database/Types/Mysql/EnumType.php
+++ b/src/Database/Types/Mysql/EnumType.php
@@ -12,17 +12,24 @@ class EnumType extends Type
 
     public function getSQLDeclaration(array $field, AbstractPlatform $platform)
     {
-        throw new \Exception('Enum type is not supported');
-        // get allowed from $column instance???
-        // learn more about this....
+        $enumField = collect(DB::select(DB::raw('SHOW COLUMNS FROM '.DB::getQueryGrammar()->wrap($this->tableName))))->where('Field', $field['name'])->first();
 
-        $pdo = DB::connection()->getPdo();
+        if (!is_null($enumField)) {
+            return $enumField->Type;
+        } else {
+            throw new \Exception('Enum definition error');
+            // throw new \Exception('Enum type is not supported');
+            // get allowed from $column instance???
+            // learn more about this....
 
-        // trim the values
-        $allowed = array_map(function ($value) use ($pdo) {
-            return $pdo->quote(trim($value));
-        }, $allowed);
+            $pdo = DB::connection()->getPdo();
 
-        return 'enum('.implode(', ', $allowed).')';
+            // trim the values
+            $allowed = array_map(function ($value) use ($pdo) {
+                return $pdo->quote(trim($value));
+            }, $allowed);
+
+            return 'enum('.implode(', ', $allowed).')';
+        }
     }
 }

--- a/src/Database/Types/Mysql/EnumType.php
+++ b/src/Database/Types/Mysql/EnumType.php
@@ -12,17 +12,29 @@ class EnumType extends Type
 
     public function getSQLDeclaration(array $field, AbstractPlatform $platform)
     {
-        throw new \Exception('Enum type is not supported');
-        // get allowed from $column instance???
-        // learn more about this....
 
-        $pdo = DB::connection()->getPdo();
+        $enumField = collect(DB::select(DB::raw("SHOW COLUMNS FROM " . DB::getQueryGrammar()->wrap($this->tableName))))->where('Field', $field['name'])->first();
 
-        // trim the values
-        $allowed = array_map(function ($value) use ($pdo) {
-            return $pdo->quote(trim($value));
-        }, $allowed);
+        if(!is_null($enumField)){
 
-        return 'enum('.implode(', ', $allowed).')';
+            return $enumField->Type;
+
+        }else{
+
+            throw new \Exception('Enum definition error');
+
+            // throw new \Exception('Enum type is not supported');
+            // get allowed from $column instance???
+            // learn more about this....
+
+            $pdo = DB::connection()->getPdo();
+
+            // trim the values
+            $allowed = array_map(function ($value) use ($pdo) {
+                return $pdo->quote(trim($value));
+            }, $allowed);
+
+            return 'enum(' . implode(', ', $allowed) . ')';
+        }
     }
 }


### PR DESCRIPTION
In my experience working with enum types in Mysql, this problem with Voyager vs Enum types usually arise when progressively porting legacy code bases to Voyager.

[While it is clear not to use enums](http://komlenic.com/244/8-reasons-why-mysqls-enum-data-type-is-evil/), porting progressively as described above becomes difficult since Voyager currently does not allow any tables with enum cols to be edited (which usually the purpose of editing the schema may not even be about the enum col).

This PR is my attempt to resuscitate [#1923](https://github.com/the-control-group/voyager/issues/1923). Since [doctrine are stateless](https://www.doctrine-project.org/projects/doctrine-dbal/en/2.9/reference/types.html), I took a hint from [the recommended fix](https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/cookbook/mysql-enums.html), which is easy because [Voyager already has such abstraction](https://github.com/the-control-group/voyager/blob/b00a09028a264c3ed61b39d0fa6db9928a506bb9/src/Database/Types/Mysql/EnumType.php).

I believe that if this PR is accepted as the right step in the right direction, it is only a matter of time before the UI and other components of Voyager will completely support enum types.