### PR TITLE
Allows NULL on relationship with AJAX request

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -661,6 +661,14 @@ class VoyagerBaseController extends Controller
                 }
 
                 $results = [];
+
+                if (!$row->required && !$search) {
+                    $results[] = [
+                        'id'   => '',
+                        'text' => __('voyager::generic.none'),
+                    ];
+                }
+
                 foreach ($relationshipOptions as $relationshipOption) {
                     $results[] = [
                         'id'   => $relationshipOption->{$options->key},


### PR DESCRIPTION
When jSelect ask for the possible relationships the response ignore the required option of the field.

This will add back the functionality, it also prevents the output of the 'NONE' option when using the search query.

Fixes https://github.com/the-control-group/voyager/issues/4031