### PR TITLE
Skip fields if details columns is not set

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -58,7 +58,9 @@ abstract class Controller extends BaseController
             if (!$request->hasFile($row->field) && !$request->has($row->field) && $row->type !== 'checkbox') {
                 // if the field is a belongsToMany relationship, don't remove it
                 // if no content is provided, that means the relationships need to be removed
-                if (isset($row->details->type) && $row->details->type !== 'belongsToMany') {
+                if (isset($row->details->type) && $row->details->type === 'belongsToMany') {
+                    // Do nothing
+                } else {
                     continue;
                 }
             }


### PR DESCRIPTION
Some fields could have the details set as NULL or the type is not set.

This patch allow to skip thoose fields withthout details or type.
As specified in the code comments the only exceptions are:
 - Checkboxes
 - BelongsToMany relationship

Example why this is needed:
I have some columns that are managed by another laravel package, I remove thoose request arguments and I write them with that library functions and then I'll pass the request to the Voyager BREAD controller.

Unfortunatly without this patch the Voyager will override my changes due to the fact that the field is absent from the request and the field is not skipped.