### PR TITLE
Category model fix in "Add/Edit Post" template

### DIFF
--- a/resources/views/posts/edit-add.blade.php
+++ b/resources/views/posts/edit-add.blade.php
@@ -212,7 +212,7 @@
                             <div class="form-group">
                                 <label for="category_id">{{ __('voyager::post.category') }}</label>
                                 <select class="form-control" name="category_id">
-                                    @foreach(TCG\Voyager\Models\Category::all() as $category)
+                                    @foreach(Voyager::model('Category')::all() as $category)
                                         <option value="{{ $category->id }}"@if(isset($dataTypeContent->category_id) && $dataTypeContent->category_id == $category->id) selected="selected"@endif>{{ $category->name }}</option>
                                     @endforeach
                                 </select>


### PR DESCRIPTION
<!---
IF YOU'RE POSTING A QUESTION ABOUT HOW TO USE VOYAGER, PLEASE CONSIDER ASKING IN SLACK FIRST
--->
## Version information
<!--- The following information is required for bug reports.  Issues without it will be closed without response --->
 - Laravel: v5.8.27
 - Voyager: v1.2.6
 - PHP: 7.2
 - Database: MySQL 5.7

## Description
<!--- Describe the bug --->
By default, the "Add/Edit Post" template uses a hard-coded model class facade to populate a dropdown box with Categories.  Using a custom Category model with a different namespace results in a 500 error.

## Steps To Reproduce
Steps to reproduce the behavior:
1. Sub-class the Voyager Admin model in your own application namespace (by adding Voyager::useModel(...) calls to AppServiceProvider#register)
2. Log into Voyager Admin backend
3. Click the "Posts" menu item
4. Click "Add New"
4. See error

## Expected behavior
The "Add/Edit Post" screen should load without error.