### PR TITLE
Hide delete button when has no delete permission

### DIFF
--- a/resources/views/settings/index.blade.php
+++ b/resources/views/settings/index.blade.php
@@ -256,10 +256,12 @@
                                     <a href="{{ route('voyager.settings.move_down', $setting->id) }}">
                                         <i class="sort-icons voyager-sort-desc"></i>
                                     </a>
+                                    @can('delete', Voyager::model('Setting'))
                                     <i class="voyager-trash"
                                        data-id="{{ $setting->id }}"
                                        data-display-key="{{ $setting->key }}"
                                        data-display-name="{{ $setting->display_name }}"></i>
+                                    @endcan
                                 </div>
                             </div>
 
@@ -411,6 +413,7 @@
         @endcan
     </div>
 
+    @can('delete', Voyager::model('Setting'))
     <div class="modal modal-danger fade" tabindex="-1" id="delete_modal" role="dialog">
         <div class="modal-dialog">
             <div class="modal-content">
@@ -433,6 +436,7 @@
             </div>
         </div>
     </div>
+    @endcan
 
 @stop
 
@@ -448,6 +452,7 @@
                 }
             });
 
+            @can('delete', Voyager::model('Setting'))
             $('.panel-actions .voyager-trash').click(function () {
                 var display = $(this).data('display-name') + '/' + $(this).data('display-key');
 
@@ -456,6 +461,7 @@
                 $('#delete_form')[0].action = '{{ route('voyager.settings.delete', [ 'id' => '__id' ]) }}'.replace('__id', $(this).data('id'));
                 $('#delete_modal').modal('show');
             });
+            @endcan
 
             $('.toggleswitch').bootstrapToggle();
 


### PR DESCRIPTION
Hide delete button in Settings page when the user has no **delete settings** permission.
So instead of the forbidden action exception (code 403),
the user won't be able to see/click the delete button