### PR TITLE
Skip translation if multilingual is not enabled

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -131,6 +131,11 @@ trait Translatable
      */
     public function getTranslatedAttribute($attribute, $language = null, $fallback = true)
     {
+        // If multilingual is not enabled don't check for translations
+        if (!config('voyager.multilingual.enabled')) {
+            return $this->getAttributeValue($attribute);
+        }
+
         list($value) = $this->getTranslatedAttributeMeta($attribute, $language, $fallback);
 
         return $value;


### PR DESCRIPTION
Following #4283 this PR skips all checks and db queries if multilingual is not enabled.

As coding style I would prefer to have:
```php
    public function getTranslatedAttribute($attribute, $language = null, $fallback = true)
    {
        // If multilingual is not enabled don't check for translations
        if (!config('voyager.multilingual.enabled')) {
            $value = $this->getAttributeValue($attribute);
        } else {
            list($value) = $this->getTranslatedAttributeMeta($attribute, $language, $fallback);
        }

        return $value;
     }
```

Please let me know which one you prefer.
