### PR TITLE
[1.x] Allow to have non-default admin guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Made with ❤️ by [The Control Group](https://www.thecontrolgroup.com)
 
 ![Voyager Screenshot](https://s3.amazonaws.com/thecontrolgroup/voyager-screenshot.png)
 
-Website & Documentation: https://laravelvoyager.com
+Website & Documentation: https://voyager.devdojo.com/
 
-Video Tutorial Here: https://laravelvoyager.com/academy/
+Video Tutorial Here: https://voyager.devdojo.com/academy/
 
 Join our Slack chat: https://voyager-slack-invitation.herokuapp.com/
 

--- a/docs/customization/separate_admin_table.md
+++ b/docs/customization/separate_admin_table.md
@@ -1,0 +1,67 @@
+# Separate admin table
+
+Since Voyager 1.2 you can keep your application users and voyager admins in a seperate table.
+
+First, create your customized model, for example `VoyagerUser`, and make sure it extends `\TCG\Voyager\Models\User`:
+
+```php
+class VoyagerUser extends \TCG\Voyager\Models\User
+{
+
+}
+```
+
+Make sure that the columns `name`, `email` and `password` are inside your migration file:
+
+```php
+public function up()
+{
+    Schema::create('voyager_users', function (Blueprint $table) {
+        $table->increments('id');
+        $table->string('name');
+        $table->string('email')->unique();
+        $table->string('password')->nullable();
+        $table->timestamps();
+    });
+}
+```
+
+Register your `VoyagerUser` model in the `boot` method of your `AppServiceProvider`:
+
+    Voyager::useModel('User', \App\VoyagerUser::class);
+
+Create a new voyager [guard](https://laravel.com/docs/5.8/authentication#adding-custom-guards) in `config/auth.php`, for example a guard called `admin`:
+
+```php
+  'guards' => [
+        'web' => [
+            'driver' => 'session',
+            'provider' => 'users',
+        ],
+
+        'admin' => [
+          'driver' => 'session',
+          'provider' => 'voyager',
+        ]
+    ],
+
+  'providers' => [
+        'users' => [
+            'driver' => 'eloquent',
+            'model' => App\User::class,
+        ],
+
+        'voyager' => [
+            'driver' => 'eloquent',
+            'model' => App\VoyagerUser::class,
+        ],
+    ],
+```
+
+Register you new guard to your `AuthServiceProvider` as explained [here](https://voyager-docs.devdojo.com/customization/custom-guard).
+
+If your `admin` guard is not the default guard of your app, and is using a driver other then `session`, then
+its necessary to specifiy the guard in `config/voyager.php`
+
+    'guard' => 'admin',
+

--- a/docs/customization/separate_admin_table.md
+++ b/docs/customization/separate_admin_table.md
@@ -58,10 +58,11 @@ Create a new voyager [guard](https://laravel.com/docs/5.8/authentication#adding-
     ],
 ```
 
-Register you new guard to your `AuthServiceProvider` as explained [here](https://voyager-docs.devdojo.com/customization/custom-guard).
+Register your new guard to your `AuthServiceProvider` as explained [here](https://voyager-docs.devdojo.com/customization/custom-guard).
 
-If your `admin` guard is not the default guard of your app, and is using a driver other then `session`, then
-its necessary to specifiy the guard in `config/voyager.php`
+If you have set `user.add_default_role_on_register` to true in your config, you need to set `user.namespace` to the namespace of your voyager user (e.g. `'\App\VoyagerUser'`).
 
-    'guard' => 'admin',
+**Note 1**: Changing the default guard to anything other then the voyager guard is only supported for `session` driver in 1.2.
+
+**Note 2**: It is assumend that the middleware `admin.user` is used for any admin route (except login).
 

--- a/docs/customization/separate_admin_table.md
+++ b/docs/customization/separate_admin_table.md
@@ -18,10 +18,16 @@ public function up()
 {
     Schema::create('voyager_users', function (Blueprint $table) {
         $table->increments('id');
+        $table->bigInteger('role_id')->unsigned()->nullable()
         $table->string('name');
         $table->string('email')->unique();
+        $table->string('avatar', 191)->nullable()->default('users/default.png');
         $table->string('password')->nullable();
+        $table->string('remember_token', 191)->nullable();
+        $table->text('settings')->nullable()->default(null);
         $table->timestamps();
+
+	$table->foreign('role_id')->references('id')->on('roles');
     });
 }
 ```

--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -41,8 +41,8 @@
                     <li class="profile-img">
                         <img src="{{ $user_avatar }}" class="profile-img">
                         <div class="profile-body">
-                            <h5>{{ app('VoyagerAuth')->user()->name }}</h5>
-                            <h6>{{ app('VoyagerAuth')->user()->email }}</h6>
+                            <h5>{{ Auth::user()->name }}</h5>
+                            <h6>{{ Auth::user()->email }}</h6>
                         </div>
                     </li>
                     <li class="divider"></li>

--- a/resources/views/dashboard/sidebar.blade.php
+++ b/resources/views/dashboard/sidebar.blade.php
@@ -19,9 +19,9 @@
                  style="background-image:url({{ Voyager::image( Voyager::setting('admin.bg_image'), voyager_asset('images/bg.jpg') ) }}); background-size: cover; background-position: 0px;">
                 <div class="dimmer"></div>
                 <div class="panel-content">
-                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ app('VoyagerAuth')->user()->name }} avatar">
-                    <h4>{{ ucwords(app('VoyagerAuth')->user()->name) }}</h4>
-                    <p>{{ app('VoyagerAuth')->user()->email }}</p>
+                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ Auth::user()->name }} avatar">
+                    <h4>{{ ucwords(Auth::user()->name) }}</h4>
+                    <p>{{ Auth::user()->email }}</p>
 
                     <a href="{{ route('voyager.profile') }}" class="btn btn-primary">{{ __('voyager::generic.profile') }}</a>
                     <div style="clear:both"></div>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -64,10 +64,10 @@
 </div>
 
 <?php
-if (starts_with(app('VoyagerAuth')->user()->avatar, 'http://') || starts_with(app('VoyagerAuth')->user()->avatar, 'https://')) {
-    $user_avatar = app('VoyagerAuth')->user()->avatar;
+if (starts_with(Auth::user()->avatar, 'http://') || starts_with(Auth::user()->avatar, 'https://')) {
+    $user_avatar = Auth::user()->avatar;
 } else {
-    $user_avatar = Voyager::image(app('VoyagerAuth')->user()->avatar);
+    $user_avatar = Voyager::image(Auth::user()->avatar);
 }
 ?>
 

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -13,13 +13,13 @@
     <div style="background-size:cover; background-image: url({{ Voyager::image( Voyager::setting('admin.bg_image'), voyager_asset('/images/bg.jpg')) }}); background-position: center center;position:absolute; top:0; left:0; width:100%; height:300px;"></div>
     <div style="height:160px; display:block; width:100%"></div>
     <div style="position:relative; z-index:9; text-align:center;">
-        <img src="@if( !filter_var(app('VoyagerAuth')->user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( app('VoyagerAuth')->user()->avatar ) }}@else{{ app('VoyagerAuth')->user()->avatar }}@endif"
+        <img src="@if( !filter_var(Auth::user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( Auth::user()->avatar ) }}@else{{ Auth::user()->avatar }}@endif"
              class="avatar"
              style="border-radius:50%; width:150px; height:150px; border:5px solid #fff;"
-             alt="{{ app('VoyagerAuth')->user()->name }} avatar">
-        <h4>{{ ucwords(app('VoyagerAuth')->user()->name) }}</h4>
-        <div class="user-email text-muted">{{ ucwords(app('VoyagerAuth')->user()->email) }}</div>
-        <p>{{ app('VoyagerAuth')->user()->bio }}</p>
-        <a href="{{ route('voyager.users.edit', app('VoyagerAuth')->user()->getKey()) }}" class="btn btn-primary">{{ __('voyager::profile.edit') }}</a>
+             alt="{{ Auth::user()->name }} avatar">
+        <h4>{{ ucwords(Auth::user()->name) }}</h4>
+        <div class="user-email text-muted">{{ ucwords(Auth::user()->email) }}</div>
+        <p>{{ Auth::user()->bio }}</p>
+        <a href="{{ route('voyager.users.edit', Auth::user()->getKey()) }}" class="btn btn-primary">{{ __('voyager::profile.edit') }}</a>
     </div>
 @stop

--- a/src/FormFields/MediaPickerHandler.php
+++ b/src/FormFields/MediaPickerHandler.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\FormFields;
 
 use Illuminate\Support\Str;
+use Auth;
 
 class MediaPickerHandler extends AbstractHandler
 {
@@ -26,7 +27,7 @@ class MediaPickerHandler extends AbstractHandler
         }
 
         if (isset($options->base_path)) {
-            $options->base_path = str_replace('{uid}', app('VoyagerAuth')->user()->getKey(), $options->base_path);
+            $options->base_path = str_replace('{uid}', Auth::user()->getKey(), $options->base_path);
             if (Str::contains($options->base_path, '{date:')) {
                 $options->base_path = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                     return \Carbon\Carbon::now()->format($date[1]);

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -275,22 +275,5 @@ abstract class Controller extends BaseController
 
             return !empty($value->details->validation->rule);
         });
-    }
-
-    /**
-     * Authorize a given action for the current user.
-     *
-     * @param mixed       $ability
-     * @param mixed|array $arguments
-     *
-     * @throws \Illuminate\Auth\Access\AuthorizationException
-     *
-     * @return \Illuminate\Auth\Access\Response
-     */
-    public function authorize($ability, $arguments = [])
-    {
-        $user = app('VoyagerAuth')->user();
-
-        return $this->authorizeForUser($user, $ability, $arguments);
-    }
+    }    
 }

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -13,6 +13,7 @@ use TCG\Voyager\Events\BreadDataUpdated;
 use TCG\Voyager\Events\BreadImagesDeleted;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Http\Controllers\Traits\BreadRelationshipParser;
+use Auth;
 
 class VoyagerBaseController extends Controller
 {
@@ -82,7 +83,7 @@ class VoyagerBaseController extends Controller
             }
 
             // Use withTrashed() if model uses SoftDeletes and if toggle is selected
-            if ($model && in_array(SoftDeletes::class, class_uses($model)) && app('VoyagerAuth')->user()->can('delete', app($dataType->model_name))) {
+            if ($model && in_array(SoftDeletes::class, class_uses($model)) && Auth::user()->can('delete', app($dataType->model_name))) {
                 $usesSoftDeletes = true;
 
                 if ($request->get('showSoftDeleted')) {

--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Storage;
 use Intervention\Image\Constraint;
 use Intervention\Image\Facades\Image;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class VoyagerController extends Controller
 {
@@ -18,7 +19,7 @@ class VoyagerController extends Controller
 
     public function logout()
     {
-        app('VoyagerAuth')->logout();
+        Auth::logout();
 
         return redirect()->route('voyager.login');
     }

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -11,6 +11,7 @@ use Intervention\Image\Facades\Image;
 use League\Flysystem\Plugin\ListWith;
 use TCG\Voyager\Events\MediaFileAdded;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class VoyagerMediaController extends Controller
 {
@@ -232,7 +233,7 @@ class VoyagerMediaController extends Controller
                     $name = get_file_name($name);
                 }
             } else {
-                $name = str_replace('{uid}', app('VoyagerAuth')->user()->getKey(), $request->get('filename'));
+                $name = str_replace('{uid}', Auth::user()->getKey(), $request->get('filename'));
                 if (Str::contains($name, '{date:')) {
                     $name = preg_replace_callback('/\{date:([^\/\}]*)\}/', function ($date) {
                         return \Carbon\Carbon::now()->format($date[1]);

--- a/src/Http/Controllers/VoyagerUserController.php
+++ b/src/Http/Controllers/VoyagerUserController.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Http\Controllers;
 
 use Illuminate\Http\Request;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class VoyagerUserController extends VoyagerBaseController
 {
@@ -15,11 +16,11 @@ class VoyagerUserController extends VoyagerBaseController
     // POST BR(E)AD
     public function update(Request $request, $id)
     {
-        if (app('VoyagerAuth')->user()->getKey() == $id) {
+        if (Auth::user()->getKey() == $id) {
             $request->merge([
-                'role_id'                              => app('VoyagerAuth')->user()->role_id,
-                'user_belongsto_role_relationship'     => app('VoyagerAuth')->user()->role_id,
-                'user_belongstomany_role_relationship' => app('VoyagerAuth')->user()->roles->pluck('id')->toArray(),
+                'role_id'                              => Auth::user()->role_id,
+                'user_belongsto_role_relationship'     => Auth::user()->role_id,
+                'user_belongstomany_role_relationship' => Auth::user()->roles->pluck('id')->toArray(),
             ]);
         }
 

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -17,11 +17,8 @@ class VoyagerAdminMiddleware
     public function handle($request, Closure $next)
     {
         if (!app('VoyagerAuth')->guest()) {
-
-            // Set default guard to voyager admin
-            if (!empty($guard = config('voyager.guard'))) {
-                auth()->setDefaultDriver($guard);
-            } elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
+            // Set default guard to voyager admin, only supported for SessionGuard
+            if (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
                 // Extract guard name from unique identifier for the auth session value
                 preg_match('/(?<=_).*(?=_)/', app('VoyagerAuth')->getName(), $matches);
                 auth()->setDefaultDriver($matches[0]);

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -19,10 +19,10 @@ class VoyagerAdminMiddleware
         if (!app('VoyagerAuth')->guest()) {
 
             // Set default guard to voyager admin
-            if (!empty($guard = config('voyager.guard'))){
+            if (!empty($guard = config('voyager.guard'))) {
                 auth()->setDefaultDriver($guard);
             }
-            elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard){
+            elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
               // Extract guard name from unique identifier for the auth session value
               preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
               auth()->setDefaultDriver($matches[0]);

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -21,8 +21,7 @@ class VoyagerAdminMiddleware
             // Set default guard to voyager admin
             if (!empty($guard = config('voyager.guard'))) {
                 auth()->setDefaultDriver($guard);
-            }
-            elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
+            } elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
               // Extract guard name from unique identifier for the auth session value
               preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
               auth()->setDefaultDriver($matches[0]);

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -23,7 +23,7 @@ class VoyagerAdminMiddleware
                 auth()->setDefaultDriver($guard);
             } elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
                 // Extract guard name from unique identifier for the auth session value
-                preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
+                preg_match('/(?<=_).*(?=_)/', app('VoyagerAuth')->getName(), $matches);
                 auth()->setDefaultDriver($matches[0]);
             }
 

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -19,10 +19,10 @@ class VoyagerAdminMiddleware
         if (!app('VoyagerAuth')->guest()) {
 
             // Set default guard to voyager admin
-            if(!empty($guard = config('voyager.guard'))){
+            if (!empty($guard = config('voyager.guard'))){
                 auth()->setDefaultDriver($guard);
             }
-            elseif(app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard){
+            elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard){
               // Extract guard name from unique identifier for the auth session value
               preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
               auth()->setDefaultDriver($matches[0]);

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -22,9 +22,9 @@ class VoyagerAdminMiddleware
             if (!empty($guard = config('voyager.guard'))) {
                 auth()->setDefaultDriver($guard);
             } elseif (app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard) {
-              // Extract guard name from unique identifier for the auth session value
-              preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
-              auth()->setDefaultDriver($matches[0]);
+                // Extract guard name from unique identifier for the auth session value
+                preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
+                auth()->setDefaultDriver($matches[0]);
             }
 
             $user = app('VoyagerAuth')->user();

--- a/src/Http/Middleware/VoyagerAdminMiddleware.php
+++ b/src/Http/Middleware/VoyagerAdminMiddleware.php
@@ -17,6 +17,17 @@ class VoyagerAdminMiddleware
     public function handle($request, Closure $next)
     {
         if (!app('VoyagerAuth')->guest()) {
+
+            // Set default guard to voyager admin
+            if(!empty($guard = config('voyager.guard'))){
+                auth()->setDefaultDriver($guard);
+            }
+            elseif(app('VoyagerAuth') instanceof \Illuminate\Auth\SessionGuard){
+              // Extract guard name from unique identifier for the auth session value
+              preg_match('/(?<=_).*(?=_)/',app('VoyagerAuth')->getName(), $matches);
+              auth()->setDefaultDriver($matches[0]);
+            }
+
             $user = app('VoyagerAuth')->user();
             app()->setLocale($user->locale ?? app()->getLocale());
 

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
 use TCG\Voyager\Events\MenuDisplay;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 /**
  * @todo: Refactor this class by using something like MenuBuilder Helper.
@@ -140,7 +141,7 @@ class Menu extends Model
 
         // Filter items by permission
         $items = $items->filter(function ($item) {
-            return !$item->children->isEmpty() || app('VoyagerAuth')->user()->can('browse', $item);
+            return !$item->children->isEmpty() || Auth::user()->can('browse', $item);
         })->filter(function ($item) {
             // Filter out empty menu-items
             if ($item->url == '' && $item->route == '' && $item->children->count() == 0) {

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Traits\Translatable;
+use Auth;
 
 class Page extends Model
 {
@@ -29,8 +30,8 @@ class Page extends Model
     public function save(array $options = [])
     {
         // If no author has been assigned, assign the current user's id as the author of the post
-        if (!$this->author_id && app('VoyagerAuth')->user()) {
-            $this->author_id = app('VoyagerAuth')->user()->getKey();
+        if (!$this->author_id && Auth::user()) {
+            $this->author_id = Auth::user()->getKey();
         }
 
         parent::save();

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Model;
 use TCG\Voyager\Facades\Voyager;
 use TCG\Voyager\Traits\Resizable;
 use TCG\Voyager\Traits\Translatable;
+use Auth;
 
 class Post extends Model
 {
@@ -22,8 +23,8 @@ class Post extends Model
     public function save(array $options = [])
     {
         // If no author has been assigned, assign the current user's id as the author of the post
-        if (!$this->author_id && app('VoyagerAuth')->user()) {
-            $this->author_id = app('VoyagerAuth')->user()->getKey();
+        if (!$this->author_id && Auth::user()) {
+            $this->author_id = Auth::user()->getKey();
         }
 
         parent::save();

--- a/src/Widgets/PageDimmer.php
+++ b/src/Widgets/PageDimmer.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Widgets;
 
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class PageDimmer extends BaseDimmer
 {
@@ -42,6 +43,6 @@ class PageDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return app('VoyagerAuth')->user()->can('browse', Voyager::model('Page'));
+        return Auth::user()->can('browse', Voyager::model('Page'));
     }
 }

--- a/src/Widgets/PostDimmer.php
+++ b/src/Widgets/PostDimmer.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Widgets;
 
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class PostDimmer extends BaseDimmer
 {
@@ -42,6 +43,6 @@ class PostDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return app('VoyagerAuth')->user()->can('browse', Voyager::model('Post'));
+        return Auth::user()->can('browse', Voyager::model('Post'));
     }
 }

--- a/src/Widgets/UserDimmer.php
+++ b/src/Widgets/UserDimmer.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Widgets;
 
 use Illuminate\Support\Str;
 use TCG\Voyager\Facades\Voyager;
+use Auth;
 
 class UserDimmer extends BaseDimmer
 {
@@ -42,6 +43,6 @@ class UserDimmer extends BaseDimmer
      */
     public function shouldBeDisplayed()
     {
-        return app('VoyagerAuth')->user()->can('browse', Voyager::model('User'));
+        return Auth::user()->can('browse', Voyager::model('User'));
     }
 }


### PR DESCRIPTION
Fixes #4262 and #4334.

This is a follow up to #3968, and adds the support for non-default admin guards as requested a couple of times (#2572,#2534,#2568, #3398, #2002).

Changing the default guard driver in `VoyagerAdminMiddleware` makes sure that  

```
// via controller
$canViewPost = $this->authorize('read', $post);
```

and 

    @can

work when the guard is changed to a non-default admin guard. This fixes a bug that when the  guard was changed (possible since #3968) to a non-default guard, it wasn't possible to open any protected page `403 This action is unauthorized.` (#4262) and action buttons did not show up (#4334).

I also created a short description in the docs, how to separate admin and users , since it has also been asked a couple of times.