### PR TITLE
Validate fields without ajax

### DIFF
--- a/src/Http/Controllers/VoyagerRoleController.php
+++ b/src/Http/Controllers/VoyagerRoleController.php
@@ -18,19 +18,14 @@ class VoyagerRoleController extends VoyagerBaseController
         $this->authorize('edit', app($dataType->model_name));
 
         //Validate fields with ajax
-        $val = $this->validateBread($request->all(), $dataType->editRows);
+        $val = $this->validateBread($request->all(), $dataType->editRows, $dataType->name, $id)->validate();
 
-        if ($val->fails()) {
-            return response()->json(['errors' => $val->messages()]);
-        }
+        $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
+        $this->insertUpdateData($request, $slug, $dataType->editRows, $data);
 
-        if (!$request->ajax()) {
-            $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
-            $this->insertUpdateData($request, $slug, $dataType->editRows, $data);
+        $data->permissions()->sync($request->input('permissions', []));
 
-            $data->permissions()->sync($request->input('permissions', []));
-
-            return redirect()
+        return redirect()
             ->route("voyager.{$dataType->slug}.index")
             ->with([
                 'message'    => __('voyager::generic.successfully_updated')." {$dataType->getTranslatedAttribute('display_name_singular')}",
@@ -50,19 +45,14 @@ class VoyagerRoleController extends VoyagerBaseController
         $this->authorize('add', app($dataType->model_name));
 
         //Validate fields with ajax
-        $val = $this->validateBread($request->all(), $dataType->addRows);
+        $val = $this->validateBread($request->all(), $dataType->addRows)->validate();
 
-        if ($val->fails()) {
-            return response()->json(['errors' => $val->messages()]);
-        }
+        $data = new $dataType->model_name();
+        $this->insertUpdateData($request, $slug, $dataType->addRows, $data);
 
-        if (!$request->ajax()) {
-            $data = new $dataType->model_name();
-            $this->insertUpdateData($request, $slug, $dataType->addRows, $data);
+        $data->permissions()->sync($request->input('permissions', []));
 
-            $data->permissions()->sync($request->input('permissions', []));
-
-            return redirect()
+        return redirect()
             ->route("voyager.{$dataType->slug}.index")
             ->with([
                 'message'    => __('voyager::generic.successfully_added_new')." {$dataType->getTranslatedAttribute('display_name_singular')}",


### PR DESCRIPTION
When we add unique column validation in Roles bread, it gives unique column validation error even in case of updating the roles. Show text plain with error