### PR TITLE
Removed stray tabs within the code editor div

### DIFF
--- a/resources/views/formfields/code_editor.blade.php
+++ b/resources/views/formfields/code_editor.blade.php
@@ -1,4 +1,2 @@
-<div id="{{ $row->field }}" data-theme="{{ @$options->theme }}" data-language="{{ @$options->language }}" class="ace_editor min_height_200" name="{{ $row->field }}">
-    {{ old($row->field, $dataTypeContent->{$row->field} ?? $options->default ?? '') }}
-</div>
+<div id="{{ $row->field }}" data-theme="{{ @$options->theme }}" data-language="{{ @$options->language }}" class="ace_editor min_height_200" name="{{ $row->field }}">{{ old($row->field, $dataTypeContent->{$row->field} ?? $options->default ?? '') }}</div>
 <textarea name="{{ $row->field }}" id="{{ $row->field }}_textarea" class="hidden">{{ old($row->field, $dataTypeContent->{$row->field} ?? $options->default ?? '') }}</textarea>


### PR DESCRIPTION
Newline/tabs within the div show up when you use the formfield - have removed these