### PR TITLE
Update actions.blade.php to fix get_class fail on string

### DIFF
--- a/resources/views/bread/partials/actions.blade.php
+++ b/resources/views/bread/partials/actions.blade.php
@@ -1,7 +1,8 @@
 @if($data)
     @php
         // need to recreate object because policy might depend on record data
-        $class = get_class($action);
+        $class = is_object($action) ? get_class($action) : $action;
+        
         $action = new $class($dataType, $data);
     @endphp
     @can ($action->getPolicy(), $data)


### PR DESCRIPTION
In older Voyager version this code worked for me:

```php
class AppServiceProvider extends ServiceProvider
{
...
   public function boot()
    {
... 
            Voyager::replaceAction(DeleteAction::class, TenantDeleteAction::class);
...
     }
...
}
```

But after Voyager update it stopped working as "get_class" fails on string.