### PR TITLE
Cache check permission 

### DIFF
--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -93,7 +93,7 @@ class BasePolicy
     }
 
     /**
-     * Purge cache, needed only for tests
+     * Purge cache, needed only for tests.
      *
      * @return void
      */

--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -91,4 +91,14 @@ class BasePolicy
 
         return self::$cache[$key];
     }
+
+    /**
+     * Purge cache, needed only for tests
+     *
+     * @return void
+     */
+    public static function purgeCache()
+    {
+        self::$cache = [];
+    }
 }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,6 +4,7 @@ namespace TCG\Voyager\Tests\Feature;
 
 use Illuminate\Support\Facades\Auth;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Policies\BasePolicy;
 use TCG\Voyager\Tests\TestCase;
 
 class DashboardTest extends TestCase
@@ -65,6 +66,8 @@ class DashboardTest extends TestCase
             $user->role->permissions()->where('key', 'browse_users')->first()
         );
 
+        BasePolicy::purgeCache();
+
         $this->visit(route('voyager.dashboard'))
             ->see(__('voyager::generic.dashboard'));
 
@@ -86,6 +89,8 @@ class DashboardTest extends TestCase
             $user->role->permissions()->where('key', 'browse_posts')->first()
         );
 
+        BasePolicy::purgeCache();
+
         $this->visit(route('voyager.dashboard'))
             ->see(__('voyager::generic.dashboard'));
 
@@ -106,6 +111,8 @@ class DashboardTest extends TestCase
         $user->role->permissions()->detach(
             $user->role->permissions()->where('key', 'browse_pages')->first()
         );
+
+        BasePolicy::purgeCache();
 
         $this->visit(route('voyager.dashboard'))
             ->see(__('voyager::generic.dashboard'));

--- a/tests/FormfieldsTest.php
+++ b/tests/FormfieldsTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Schema;
 use TCG\Voyager\Models\Category;
 use TCG\Voyager\Models\DataType;
 use TCG\Voyager\Models\Permission;
+use TCG\Voyager\Policies\BasePolicy;
 
 class FormfieldsTest extends TestCase
 {
@@ -381,5 +382,7 @@ class FormfieldsTest extends TestCase
 
         // Attach permissions to role
         Auth::user()->role->permissions()->syncWithoutDetaching(Permission::all()->pluck('id'));
+
+        BasePolicy::purgeCache();
     }
 }

--- a/tests/UserProfileTest.php
+++ b/tests/UserProfileTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\User;
+use TCG\Voyager\Policies\BasePolicy;
 
 class UserProfileTest extends TestCase
 {
@@ -111,6 +112,9 @@ class UserProfileTest extends TestCase
             'browse_admin',
             'browse_users',
         ])->get()->pluck('id')->all());
+
+        BasePolicy::purgeCache();
+
         Auth::onceUsingId($user->id);
         $this->visit(route('voyager.profile'))
              ->click(__('voyager::profile.edit'))
@@ -151,6 +155,8 @@ class UserProfileTest extends TestCase
         $user->role->permissions()->detach(
             $user->role->permissions()->where('key', 'browse_users')->first()
         );
+
+        BasePolicy::purgeCache();
 
         $this->visit($this->editPageForTheCurrentUser)
              ->press(__('voyager::generic.save'))


### PR DESCRIPTION
Cache check permission in basePolicy for CACHE_TIME seconds.

This cache last only for few seconds so there is no need to destroy cache after changing permissions or roles, it's mostly useful to avoid repeating the same query to check permission in browse view.

In my testing in voyager with dummy, browse Post, that has 3 actions this PR makes page generation 16% faster.

Of course with server side pagination the difference in time is negligible but noticeable with client side  pagination and many records.