### PR TITLE
Update the way of generating breadcrumbs segments.

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -7,7 +7,8 @@
             @section('breadcrumbs')
             <ol class="breadcrumb hidden-xs">
                 @php
-                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard'), '', Request::path())));
+                $requestPath = '/'.Request::path();
+                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard',[], false), '', $requestPath)));
                 $url = route('voyager.dashboard');
                 @endphp
                 @if(count($segments) == 0)

--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -7,7 +7,7 @@
             @section('breadcrumbs')
             <ol class="breadcrumb hidden-xs">
                 @php
-                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard'), '', Request::url())));
+                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard'), '', Request::path())));
                 $url = route('voyager.dashboard');
                 @endphp
                 @if(count($segments) == 0)


### PR DESCRIPTION
Using Request::path() instead of Request::url() will give us only the used portion of URI for generating segments.
Also using route('voyager.dashboard',[], false) will return relative route.
The whole idea is to avoid conflicts in URL Schema (https, http) and that when using nginx proxy_pass from https to http. which in the end will break the breadcrumbs generating.