### PR TITLE
Fix searching in a relationship with additional attributes

### DIFF
--- a/docs/customization/custom-realtionship-attributes.md
+++ b/docs/customization/custom-realtionship-attributes.md
@@ -19,3 +19,11 @@ public $additional_attributes = ['full_name'];
 
 Thats it! You can now select `full_name` in your Relationship.
 
+If you choose to use a `HasMany` or `BelongsToMany` relationship the results will be shown in a multiselect to the user.
+The multiselect wil search on the custom attribute set in `$additional_attributes`, and if this attribute does not exist in the database it will fail.
+To get around this we can specify the search attribute on the model by using the following code:
+
+```php
+public $search_attribute = 'last_name';
+```
+

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -832,17 +832,16 @@ class VoyagerBaseController extends Controller
             if ($row->field === $request->input('type')) {
                 $options = $row->details;
                 $skip = $on_page * ($page - 1);
+                $model = app($options->model);
 
                 // If search query, use LIKE to filter results depending on field label
                 if ($search) {
-                    $total_count = app($options->model)->where($options->label, 'LIKE', '%'.$search.'%')->count();
-                    $relationshipOptions = app($options->model)->take($on_page)->skip($skip)
-                        ->where($options->label, 'LIKE', '%'.$search.'%')
-                        ->get();
-                } else {
-                    $total_count = app($options->model)->count();
-                    $relationshipOptions = app($options->model)->take($on_page)->skip($skip)->get();
+                    $label = $model->search_attribute ?? $options->label;
+                    $model = $model->where($label, 'LIKE', '%'.$search.'%');
                 }
+
+                $total_count = $model->count();
+                $relationshipOptions = $model->take($on_page)->skip($skip)->get();
 
                 $results = [];
 


### PR DESCRIPTION
Currently, when searching in a relationship with an $additional_attribute on the model being searched, a QueryException is thrown: ```SQLSTATE[42S22]: Column not found: 1054 Unknown column 'product_group_and_product_group_subject' in 'where clause' (SQL: select count(*) as aggregate from `product_group_subjects` where `product_group_and_product_group_subject` LIKE %beheer%)```

This pull request adds the feature to configure the attribute of the model being searched so there will be no exception, but actual search results.

If this pull request is merged, the documentation at https://voyager-docs.devdojo.com/customization/custom-realtionship-attributes has to be improved to reflect the addition.

The change is backwards compatible.