### PR TITLE
Support database table prefix in connection

### DIFF
--- a/migrations/2017_11_26_015000_create_user_roles_table.php
+++ b/migrations/2017_11_26_015000_create_user_roles_table.php
@@ -14,7 +14,7 @@ class CreateUserRolesTable extends Migration
     public function up()
     {
         Schema::create('user_roles', function (Blueprint $table) {
-            $type = DB::connection()->getDoctrineColumn('users', 'id')->getType()->getName();
+            $type = DB::connection()->getDoctrineColumn(DB::getTablePrefix().'users', 'id')->getType()->getName();
             if ($type == 'bigint') {
                 $table->bigInteger('user_id')->unsigned()->index();
             } else {

--- a/resources/views/tools/bread/index.blade.php
+++ b/resources/views/tools/bread/index.blade.php
@@ -28,8 +28,8 @@
                     <tr>
                         <td>
                             <p class="name">
-                                <a href="{{ route('voyager.database.show', $table->name) }}"
-                                   data-name="{{ $table->name }}" class="desctable">
+                                <a href="{{ route('voyager.database.show', $table->prefix.$table->name) }}"
+                                   data-name="{{ $table->prefix.$table->name }}" class="desctable">
                                    {{ $table->name }}
                                 </a>
                                 <i class="voyager-data"

--- a/resources/views/tools/database/index.blade.php
+++ b/resources/views/tools/database/index.blade.php
@@ -30,8 +30,8 @@
                     <tr>
                         <td>
                             <p class="name">
-                                <a href="{{ route('voyager.database.show', $table->name) }}"
-                                   data-name="{{ $table->name }}" class="desctable">
+                                <a href="{{ route('voyager.database.show', $table->prefix.$table->name) }}"
+                                   data-name="{{ $table->prefix.$table->name }}" class="desctable">
                                    {{ $table->name }}
                                 </a>
                             </p>
@@ -63,14 +63,14 @@
 
                         <td class="actions">
                             <a class="btn btn-danger btn-sm pull-right delete_table @if($table->dataTypeId) remove-bread-warning @endif"
-                               data-table="{{ $table->name }}">
+                               data-table="{{ $table->prefix.$table->name }}">
                                <i class="voyager-trash"></i> {{ __('voyager::generic.delete') }}
                             </a>
-                            <a href="{{ route('voyager.database.edit', $table->name) }}"
+                            <a href="{{ route('voyager.database.edit', $table->prefix.$table->name) }}"
                                class="btn btn-sm btn-primary pull-right" style="display:inline; margin-right:10px;">
                                <i class="voyager-edit"></i> {{ __('voyager::generic.edit') }}
                             </a>
-                            <a href="{{ route('voyager.database.show', $table->name) }}"
+                            <a href="{{ route('voyager.database.show', $table->prefix.$table->name) }}"
                                data-name="{{ $table->name }}"
                                class="btn btn-sm btn-warning pull-right desctable" style="display:inline; margin-right:10px;">
                                <i class="voyager-eye"></i> {{ __('voyager::generic.view') }}

--- a/src/Http/Controllers/VoyagerBreadController.php
+++ b/src/Http/Controllers/VoyagerBreadController.php
@@ -23,7 +23,10 @@ class VoyagerBreadController extends Controller
         $dataTypes = Voyager::model('DataType')->select('id', 'name', 'slug')->get()->keyBy('name')->toArray();
 
         $tables = array_map(function ($table) use ($dataTypes) {
+            $table = Str::replaceFirst(DB::getTablePrefix(), '', $table);
+
             $table = [
+                'prefix'     => DB::getTablePrefix(),
                 'name'       => $table,
                 'slug'       => $dataTypes[$table]['slug'] ?? null,
                 'dataTypeId' => $dataTypes[$table]['id'] ?? null,
@@ -51,8 +54,8 @@ class VoyagerBreadController extends Controller
 
         $data = $this->prepopulateBreadInfo($table);
         $data['fieldOptions'] = SchemaManager::describeTable((isset($dataType) && strlen($dataType->model_name) != 0)
-            ? app($dataType->model_name)->getTable()
-            : $table
+            ? DB::getTablePrefix().app($dataType->model_name)->getTable()
+            : DB::getTablePrefix().$table
         );
 
         return Voyager::view('voyager::tools.bread.edit-add', $data);
@@ -119,8 +122,8 @@ class VoyagerBreadController extends Controller
         $dataType = Voyager::model('DataType')->whereName($table)->first();
 
         $fieldOptions = SchemaManager::describeTable((strlen($dataType->model_name) != 0)
-            ? app($dataType->model_name)->getTable()
-            : $dataType->name
+            ? DB::getTablePrefix().app($dataType->model_name)->getTable()
+            : DB::getTablePrefix().$dataType->name
         );
 
         $isModelTranslatable = is_bread_translatable($dataType);

--- a/src/Http/Controllers/VoyagerDatabaseController.php
+++ b/src/Http/Controllers/VoyagerDatabaseController.php
@@ -27,7 +27,10 @@ class VoyagerDatabaseController extends Controller
         $dataTypes = Voyager::model('DataType')->select('id', 'name', 'slug')->get()->keyBy('name')->toArray();
 
         $tables = array_map(function ($table) use ($dataTypes) {
+            $table = Str::replaceFirst(DB::getTablePrefix(), '', $table);
+
             $table = [
+                'prefix'     => DB::getTablePrefix(),
                 'name'       => $table,
                 'slug'       => $dataTypes[$table]['slug'] ?? null,
                 'dataTypeId' => $dataTypes[$table]['id'] ?? null,

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -96,8 +96,8 @@ class DataType extends Model
 
             if ($this->fill($requestData)->save()) {
                 $fields = $this->fields((strlen($this->model_name) != 0)
-                    ? app($this->model_name)->getTable()
-                    : Arr::get($requestData, 'name')
+                    ? DB::getTablePrefix().app($this->model_name)->getTable()
+                    : DB::getTablePrefix().Arr::get($requestData, 'name')
                 );
 
                 $requestData = $this->getRelationships($requestData, $fields);


### PR DESCRIPTION
Currently, even fixing the error in install, if prefix is set in database configuration Voyager BREAD management doesn't work:

- BREADs are not recognized
- Trying to add or edit BREAD will not show fields

This PR fixes that and makes the use of prefix transparent for the user that will only see table prefix while editing or creating tables, in that case prefix need to be used in Table Name field

Fixes #4541

@enniosousa if you need to use table prefix in connection you could try this PR.