### PR TITLE
Fix date for Safari

### DIFF
--- a/resources/views/bread/edit-add.blade.php
+++ b/resources/views/bread/edit-add.blade.php
@@ -167,9 +167,15 @@
             //Init datepicker for date fields if data-datepicker attribute defined
             //or if browser does not handle date inputs
             $('.form-group input[type=date]').each(function (idx, elt) {
-                if (elt.type != 'date' || elt.hasAttribute('data-datepicker')) {
+                if (elt.hasAttribute('data-datepicker')) {
                     elt.type = 'text';
                     $(elt).datetimepicker($(elt).data('datepicker'));
+                } else if (elt.type != 'date') {
+                    elt.type = 'text';
+                    $(elt).datetimepicker({
+                        format: 'L',
+                        extraFormats: [ 'YYYY-MM-DD' ]
+                    }).datetimepicker($(elt).data('datepicker'));
                 }
             });
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -241,6 +241,8 @@ abstract class Controller extends BaseController
             /********** IMAGE TYPE **********/
             case 'image':
                 return (new ContentImage($request, $slug, $row, $options))->handle();
+            /********** DATE TYPE **********/
+            case 'date':
             /********** TIMESTAMP TYPE **********/
             case 'timestamp':
                 return (new Timestamp($request, $slug, $row, $options))->handle();


### PR DESCRIPTION
Use datetimepicker with correct format to show only date when not timestamp.
Extraformats is used to get value in standard ISO format.
Added date case while processing form data to convert date again to ISO format.

Timestamp and date, while using datetimepicker, always show the American format MM/DD/YYYY, that should be localized according to user chosen locale.

Fixes #4534
Fixes #1451