### PR TITLE
Prevent "SQLite doesn't support dropping foreign keys" error.

### DIFF
--- a/migrations/2017_11_26_013050_add_user_role_relationship.php
+++ b/migrations/2017_11_26_013050_add_user_role_relationship.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class AddUserRoleRelationship extends Migration
@@ -27,7 +28,9 @@ class AddUserRoleRelationship extends Migration
     public function down()
     {
         Schema::table('users', function (Blueprint $table) {
-            $table->dropForeign(['role_id']);
+            if (DB::getDriverName() !== 'sqlite') {
+                $table->dropForeign(['role_id']);
+            }
         });
 
         Schema::table('users', function (Blueprint $table) {


### PR DESCRIPTION
Since Laravel 5.7 using Blueprint::dropForeign() with SQLite throws an exception.

From https://laravel.com/docs/5.7/upgrade:
> SQLite does not support dropping foreign keys. For that reason, using the dropForeign method on a table now throws an exception. Generally, this should be considered a bug fix; however, it is listed as a breaking change out of caution.

> If you run your migrations on multiple types of databases, consider using  DB::getDriverName() in your migrations to skip unsupported foreign key methods for SQLite.

This causes failure when using Voyager with SQLite in migrations/2017_11_26_013050_add_user_role_relationship.php

**Currently you cannot use Voyager with SQLite** (Laravel > 5.7)