### PR TITLE
Fix delete bread action

### DIFF
--- a/resources/views/tools/database/index.blade.php
+++ b/resources/views/tools/database/index.blade.php
@@ -93,7 +93,7 @@
                     <h4 class="modal-title"><i class="voyager-trash"></i>  {!! __('voyager::bread.delete_bread_quest', ['table' => '<span id="delete_bread_name"></span>']) !!}</h4>
                 </div>
                 <div class="modal-footer">
-                    <form action="{{ route('voyager.bread.delete', ['id' => null]) }}" id="delete_bread_form" method="POST">
+                    <form action="#" id="delete_bread_form" method="POST">
                         {{ method_field('DELETE') }}
                         <input type="hidden" name="_token" value="{{ csrf_token() }}">
                         <input type="submit" class="btn btn-danger" value="{{ __('voyager::bread.delete_bread_conf') }}">
@@ -229,7 +229,7 @@
                 name = $(this).data('name');
 
                 $('#delete_bread_name').text(name);
-                $('#delete_bread_form')[0].action += '/' + id;
+                $('#delete_bread_form')[0].action = '{{ route('voyager.bread.delete', '__id') }}'.replace('__id', id);
                 $('#delete_bread_modal').modal('show');
             });
         });


### PR DESCRIPTION
In Laravel  ~6 associative array parameters passed are attached to query string.~ 6.6 passing null is not working anymore.
(Change here https://github.com/laravel/framework/pull/30659/files)

The += was also always adding ids on top of the previous one

Fixes #4586