### PR TITLE
Fix resource routes with UTF8 characters

### DIFF
--- a/resources/views/menus/browse.blade.php
+++ b/resources/views/menus/browse.blade.php
@@ -107,7 +107,7 @@
         });
 
         $('td').on('click', '.delete', function (e) {
-            $('#delete_form')[0].action = '{{ route('voyager.'.$dataType->slug.'.destroy', ['menu' => '__menu']) }}'.replace('__menu', $(this).data('id'));
+            $('#delete_form')[0].action = '{{ route('voyager.'.$dataType->slug.'.destroy', ['id' => '__menu']) }}'.replace('__menu', $(this).data('id'));
 
             $('#delete_modal').modal('show');
         });

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -47,7 +47,7 @@ Route::group(['as' => 'voyager.'], function () {
                 Route::get($dataType->slug.'/{id}/restore', $breadController.'@restore')->name($dataType->slug.'.restore');
                 Route::get($dataType->slug.'/relation', $breadController.'@relation')->name($dataType->slug.'.relation');
                 Route::post($dataType->slug.'/remove', $breadController.'@remove_media')->name($dataType->slug.'.media.remove');
-                Route::resource($dataType->slug, $breadController);
+                Route::resource($dataType->slug, $breadController, ['parameters' => [$dataType->slug => 'id']]);
             }
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException("Custom routes hasn't been configured because: ".$e->getMessage(), 1);

--- a/tests/UserProfileTest.php
+++ b/tests/UserProfileTest.php
@@ -25,7 +25,7 @@ class UserProfileTest extends TestCase
 
         $this->user = Auth::loginUsingId(1);
 
-        $this->editPageForTheCurrentUser = route('voyager.users.edit', ['user' => $this->user->id]);
+        $this->editPageForTheCurrentUser = route('voyager.users.edit', [$this->user->id]);
 
         $this->listOfUsers = route('voyager.users.index');
 
@@ -102,7 +102,7 @@ class UserProfileTest extends TestCase
     public function testCanEditUserEmailWithEditorPermissions()
     {
         $user = factory(\TCG\Voyager\Models\User::class)->create();
-        $editPageForTheCurrentUser = route('voyager.users.edit', ['user' => $user->id]);
+        $editPageForTheCurrentUser = route('voyager.users.edit', [$user->id]);
         $roleId = $user->role_id;
         $role = Role::find($roleId);
         // add permissions which reflect a possible editor role


### PR DESCRIPTION
By default Laravel uses resource name as placeholder in resource routes, this causes problems with Symfony route recognition and also can easily surpass the 32 characters limit for placeholder.
We don't really need to use a custom placeholer, {id} is fine enough.
More info in Issue fixed.

Fixes #4598