### PR TITLE
Support for app own locale

### DIFF
--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -325,6 +325,16 @@ class Voyager
 
     public function getLocales()
     {
-        return array_diff(scandir(realpath(__DIR__.'/../publishable/lang')), ['..', '.']);
+        $appLocales = [];
+        if ($this->filesystem->exists(resource_path('lang/vendor/voyager'))) {
+            $appLocales = array_diff(scandir(resource_path('lang/vendor/voyager')), ['..', '.']);
+        }
+
+        $vendorLocales = array_diff(scandir(realpath(__DIR__.'/../publishable/lang')), ['..', '.']);
+        $allLocales = array_merge($vendorLocales, $appLocales);
+
+        asort($allLocales);
+
+        return $allLocales;
     }
 }


### PR DESCRIPTION
Locales list is generated based on folders in `publishable/lang` and was not considering locales added by the user in `resources/lang/vendor/voyager `

Closes #4618