### PR TITLE
Fix validation for arrays

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -182,9 +182,20 @@ abstract class Controller extends BaseController
             $fieldRules = $field->details->validation->rule;
             $fieldName = $field->field;
 
+            // If field is an array apply rules to all array elements
+            $fieldName = !empty($data[$fieldName]) && is_array($data[$fieldName]) ? $fieldName.'.*' : $fieldName;
+
             // Show the field's display name on the error message
             if (!empty($field->display_name)) {
-                $customAttributes[$fieldName] = $field->getTranslatedAttribute('display_name');
+                if (!empty($data[$fieldName]) && is_array($data[$fieldName])) {
+                    foreach ($data[$fieldName] as $index => $element) {
+                        $name = $element->getClientOriginalName() ?? $index+1;
+
+                        $customAttributes[$fieldName.'.'.$index] = $field->getTranslatedAttribute('display_name').' '.$name;
+                    }
+                } else {
+                    $customAttributes[$fieldName] = $field->getTranslatedAttribute('display_name');
+                }
             }
 
             // Get the rules for the current field whatever the format it is in

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -189,7 +189,7 @@ abstract class Controller extends BaseController
             if (!empty($field->display_name)) {
                 if (!empty($data[$fieldName]) && is_array($data[$fieldName])) {
                     foreach ($data[$fieldName] as $index => $element) {
-                        $name = $element->getClientOriginalName() ?? $index+1;
+                        $name = $element->getClientOriginalName() ?? $index + 1;
 
                         $customAttributes[$fieldName.'.'.$index] = $field->getTranslatedAttribute('display_name').' '.$name;
                     }


### PR DESCRIPTION
Use fieldname.* if rules need to be applied to an array.
Apply custom display name for each element of the array adding the filename if available or index number.

A tipical use case is file upload or multiple images upload, right now is not possible to apply validation because they are passed as arrays.

Fixes #1930