### PR TITLE
Fix unable to locate publishable resources

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -73,7 +73,6 @@ class InstallCommand extends Command
         $tags = ['seeds'];
 
         $this->call('vendor:publish', ['--provider' => VoyagerServiceProvider::class, '--tag' => $tags]);
-        $this->call('vendor:publish', ['--provider' => ImageServiceProviderLaravel5::class]);
 
         $this->info('Migrating the database tables into your application');
         $this->call('migrate', ['--force' => $this->option('force')]);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -4,7 +4,6 @@ namespace TCG\Voyager\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
-use Intervention\Image\ImageServiceProviderLaravel5;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Process\Process;
 use TCG\Voyager\Providers\VoyagerDummyServiceProvider;


### PR DESCRIPTION
It's not normally needed to publish config for Intervention/Image, but in case can be done by the user with:
`php artisan vendor:publish --provider="Intervention\Image\ImageServiceProviderLaravelRecent"`

Fixes #4555