### PR TITLE
Fix server-side default sort direction

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -58,7 +58,7 @@ class VoyagerBaseController extends Controller
         }
 
         $orderBy = $request->get('order_by', $dataType->order_column);
-        $sortOrder = $request->get('sort_order', null);
+        $sortOrder = $request->get('sort_order', $dataType->order_direction);
         $usesSoftDeletes = false;
         $showSoftDeleted = false;
 


### PR DESCRIPTION
Right now when BREAD is server-side it's always sorted in descending order, this PR uses the BREAD preference instead.