### PR TITLE
Fix displaying translation 3 times when rich text box field is also translatable

### DIFF
--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -111,7 +111,7 @@
                                 @include('voyager::partials.coordinates')
                             @elseif($row->type == 'rich_text_box')
                                 @include('voyager::multilingual.input-hidden-bread-read')
-                                <p>{!! $dataTypeContent->{$row->field} !!}</p>
+                                {!! $dataTypeContent->{$row->field} !!}
                             @elseif($row->type == 'file')
                                 @if(json_decode($dataTypeContent->{$row->field}))
                                     @foreach(json_decode($dataTypeContent->{$row->field}) as $file)


### PR DESCRIPTION
Data from TinyMCE already includes the `<p>` tag.

Paragraphs can't be nested: https://www.w3.org/TR/html401/struct/text.html#h-9.3.1

Browsers automatically open/close the `<p>` tags resulting in 3 tags instead of 1. When using translations with Rich Text Box type it was filling all three `<p>` tags with the translation.

![image](https://user-images.githubusercontent.com/19204073/71190418-d69f1a00-2284-11ea-87bf-abaac4a4325f.png)
