### PR TITLE
fixed migrate issue

### DIFF
--- a/migrations/2017_01_14_005015_create_translations_table.php
+++ b/migrations/2017_01_14_005015_create_translations_table.php
@@ -14,6 +14,8 @@ class CreateTranslationsTable extends Migration
     public function up()
     {
         Schema::create('translations', function (Blueprint $table) {
+            $table->engine = 'InnoDB';
+            
             $table->increments('id');
 
             $table->string('table_name');


### PR DESCRIPTION

Error raised when try to install voyager by php artisan voyager:install

` Illuminate\Database\QueryException  : SQLSTATE[42000]: Syntax error or access
 violation: 1071 Specified key was too long; max key length is 1000 bytes (SQL:
alter table `translations` add unique `translations_table_name_column_name_forei
gn_key_locale_unique`(`table_name`, `column_name`, `foreign_key`, `locale`))`