### PR TITLE
Remove off-putting warning icon on Crop Image modal

### DIFF
--- a/resources/views/media/manager.blade.php
+++ b/resources/views/media/manager.blade.php
@@ -327,7 +327,7 @@
 
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4 class="modal-title"><i class="voyager-warning"></i> {{ __('voyager::media.crop_image') }}</h4>
+                    <h4 class="modal-title">{{ __('voyager::media.crop_image') }}</h4>
                 </div>
 
                 <div class="modal-body">


### PR DESCRIPTION
The header for the Crop Image model currently displays a warning icon:

![Screen Shot 2019-12-23 at 4 20 39 PM](https://user-images.githubusercontent.com/1786783/71389371-3dcc0f80-25a0-11ea-9abc-a6e305e2c55d.png)

This doesn't seems necessary, and is off-putting. This PR removes it:

![Screen Shot 2019-12-23 at 4 20 15 PM](https://user-images.githubusercontent.com/1786783/71389386-4886a480-25a0-11ea-85f3-2dc36415f014.png)
