### PR TITLE
Added Image Encoding Support to ContentType Image & MultipleImage

### DIFF
--- a/src/Http/Controllers/ContentTypes/Image.php
+++ b/src/Http/Controllers/ContentTypes/Image.php
@@ -16,11 +16,15 @@ class Image extends BaseType
 
             $path = $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
 
-            $filename = $this->generateFileName($file, $path);
+            $extension = $file->getClientOriginalExtension();
+            if(isset($this->options->format) && !$this->is_animated_gif($file)){
+                $extension = $this->options->format;
+            }
+            $filename = $this->generateFileName($file, $path , $extension);
 
             $image = InterventionImage::make($file);
 
-            $fullPath = $path.$filename.'.'.$file->getClientOriginalExtension();
+            $fullPath = $path.$filename.'.'.$extension;
 
             $resize_width = null;
             $resize_height = null;
@@ -49,7 +53,7 @@ class Image extends BaseType
                         $constraint->upsize();
                     }
                 }
-            )->encode($file->getClientOriginalExtension(), $resize_quality);
+            )->encode($extension, $resize_quality);
 
             if ($this->is_animated_gif($file)) {
                 Storage::disk(config('voyager.storage.disk'))->put($fullPath, file_get_contents($file), 'public');
@@ -83,17 +87,17 @@ class Image extends BaseType
                                     $constraint->upsize();
                                 }
                             }
-                        )->encode($file->getClientOriginalExtension(), $resize_quality);
+                        )->encode($extension, $resize_quality);
                     } elseif (isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                         $crop_width = $thumbnails->crop->width;
                         $crop_height = $thumbnails->crop->height;
                         $image = InterventionImage::make($file)
                             ->fit($crop_width, $crop_height)
-                            ->encode($file->getClientOriginalExtension(), $resize_quality);
+                            ->encode($extension, $resize_quality);
                     }
 
                     Storage::disk(config('voyager.storage.disk'))->put(
-                        $path.$filename.'-'.$thumbnails->name.'.'.$file->getClientOriginalExtension(),
+                        $path.$filename.'-'.$thumbnails->name.'.'.$extension,
                         (string) $image,
                         'public'
                     );
@@ -110,21 +114,21 @@ class Image extends BaseType
      *
      * @return string
      */
-    protected function generateFileName($file, $path)
+    protected function generateFileName($file, $path , $extension)
     {
         if (isset($this->options->preserveFileUploadName) && $this->options->preserveFileUploadName) {
-            $filename = basename($file->getClientOriginalName(), '.'.$file->getClientOriginalExtension());
+            $filename = basename($file->getClientOriginalName(), '.'.$extension);
             $filename_counter = 1;
 
             // Make sure the filename does not exist, if it does make sure to add a number to the end 1, 2, 3, etc...
-            while (Storage::disk(config('voyager.storage.disk'))->exists($path.$filename.'.'.$file->getClientOriginalExtension())) {
-                $filename = basename($file->getClientOriginalName(), '.'.$file->getClientOriginalExtension()).(string) ($filename_counter++);
+            while (Storage::disk(config('voyager.storage.disk'))->exists($path.$filename.'.'.$extension)) {
+                $filename = basename($file->getClientOriginalName(), '.'.$extension).(string) ($filename_counter++);
             }
         } else {
             $filename = Str::random(20);
 
             // Make sure the filename does not exist, if it does, just regenerate
-            while (Storage::disk(config('voyager.storage.disk'))->exists($path.$filename.'.'.$file->getClientOriginalExtension())) {
+            while (Storage::disk(config('voyager.storage.disk'))->exists($path.$filename.'.'.$extension)) {
                 $filename = Str::random(20);
             }
         }

--- a/src/Http/Controllers/ContentTypes/MultipleImage.php
+++ b/src/Http/Controllers/ContentTypes/MultipleImage.php
@@ -31,6 +31,11 @@ class MultipleImage extends BaseType
             $resize_width = null;
             $resize_height = null;
 
+            $extension = $file->getClientOriginalExtension();
+            if(isset($this->options->format)){
+                $extension = $this->options->format;
+            }
+
             if (isset($this->options->resize) && (
                     isset($this->options->resize->width) || isset($this->options->resize->height)
                 )) {
@@ -49,8 +54,8 @@ class MultipleImage extends BaseType
 
             $filename = Str::random(20);
             $path = $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
-            array_push($filesPath, $path.$filename.'.'.$file->getClientOriginalExtension());
-            $filePath = $path.$filename.'.'.$file->getClientOriginalExtension();
+            array_push($filesPath, $path.$filename.'.'.$extension);
+            $filePath = $path.$filename.'.'.$extension;
 
             $image = $image->resize(
                 $resize_width,
@@ -61,7 +66,7 @@ class MultipleImage extends BaseType
                         $constraint->upsize();
                     }
                 }
-            )->encode($file->getClientOriginalExtension(), $resize_quality);
+            )->encode($extension, $resize_quality);
 
             Storage::disk(config('voyager.storage.disk'))->put($filePath, (string) $image, 'public');
 
@@ -89,17 +94,17 @@ class MultipleImage extends BaseType
                                     $constraint->upsize();
                                 }
                             }
-                        )->encode($file->getClientOriginalExtension(), $resize_quality);
+                        )->encode($extension, $resize_quality);
                     } elseif (isset($this->options->thumbnails) && isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                         $crop_width = $thumbnails->crop->width;
                         $crop_height = $thumbnails->crop->height;
                         $image = InterventionImage::make($file)
                             ->fit($crop_width, $crop_height)
-                            ->encode($file->getClientOriginalExtension(), $resize_quality);
+                            ->encode($extension, $resize_quality);
                     }
 
                     Storage::disk(config('voyager.storage.disk'))->put(
-                        $path.$filename.'-'.$thumbnails->name.'.'.$file->getClientOriginalExtension(),
+                        $path.$filename.'-'.$thumbnails->name.'.'.$extension,
                         (string) $image,
                         'public'
                     );


### PR DESCRIPTION
The Image and MultipleImage now support the image format conversion supported by <b>`Intervention/Image`</b>. Here is the list of supported encoding formats.

- jpg — return JPEG encoded image data
- png — return Portable Network Graphics (PNG) encoded image data
- gif — return Graphics Interchange Format (GIF) encoded image data
- tif — return Tagged Image File Format (TIFF) encoded image data
- bmp — return Bitmap (BMP) encoded image data
- ico — return ICO encoded image data
- psd — return Photoshop Document (PSD) encoded image data
- webp — return WebP encoded image data
- data-url — encode current image data in data URI scheme (RFC 2397)

Defining the format in <b>BREAD</b> Additional field JSON schema.
```js
{
    "format": "webp"
    "resize": {
        "width": "1000",
        "height": "null"
    },
    "quality" : "70%",
    "upsize" : true,
    "thumbnails": [
        {
            "name": "medium",
            "scale": "50%"
        }
    ]
}
```
Requires the <b>`format`</b> option with value from supported format-type.