### PR TITLE
Fix display name for new BREAD field

### DIFF
--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -373,7 +373,7 @@
                                             @include('voyager::multilingual.input-hidden', [
                                                 'isModelTranslatable' => true,
                                                 '_field_name'         => 'field_display_name_' . $data['field'],
-                                                '_field_trans' => $dataRow ? get_field_translations($dataRow, 'display_name') : $data['field'],
+                                                '_field_trans' => $dataRow ? get_field_translations($dataRow, 'display_name') : json_encode([config('voyager.multilingual.default') => ucwords(str_replace('_', ' ', $data['field']))]),
                                             ])
                                         @endif
                                         <input type="text" class="form-control"


### PR DESCRIPTION
In case `$dataRow` didn't exists a string was passed to `_field_trans` instead of a json array.
Just the default language is enough in json array.

Fixes #4665