### PR TITLE
Added sorting BREAD as tree view if BREAD have column - menu_parent

### DIFF
--- a/resources/views/bread/order-tree-item.blade.php
+++ b/resources/views/bread/order-tree-item.blade.php
@@ -1,0 +1,11 @@
+<div class="dd-handle" style="height:inherit">
+    @if (isset($dataRow->details->view))
+        @include($dataRow->details->view, ['row' => $dataRow, 'dataType' => $dataType, 'dataTypeContent' => $result, 'content' => $result->{$display_column}, 'action' => 'order'])
+    @elseif($dataRow->type == 'image')
+        <span>
+            <img src="@if( !filter_var($result->{$display_column}, FILTER_VALIDATE_URL)){{ Voyager::image( $result->{$display_column} ) }}@else{{ $result->{$display_column} }}@endif" style="height:100px">
+        </span>
+    @else
+    <span>{{ $result->{$display_column} }}</span>
+    @endif
+</div>

--- a/resources/views/bread/order-tree-wrapper-with-childs.blade.php
+++ b/resources/views/bread/order-tree-wrapper-with-childs.blade.php
@@ -1,0 +1,16 @@
+<li class="dd-item" data-id="{{ $result->id }}">
+
+    <button class="dd-collapse" data-action="collapse" type="button">Collapse</button>
+    <button class="dd-expand" data-action="expand" type="button">Expand</button>
+
+    @if (isset($child_view_render)) {!! $child_view_render !!} @endif
+
+    <ol class="dd-list">
+
+        @if (isset($childrens))
+            {!! $childrens !!}
+        @endif
+        
+    </ol>
+
+</li>

--- a/resources/views/bread/order-tree-wrapper-without-childs.blade.php
+++ b/resources/views/bread/order-tree-wrapper-without-childs.blade.php
@@ -1,0 +1,3 @@
+<li class="dd-item" data-id="{{ $result->id }}">
+    @if (isset($child_view_render)) {!! $child_view_render !!} @endif
+</li>


### PR DESCRIPTION
I did a great job so that we can sort our BREAD resources in a tree view.

If BREAD have column named as _menu_parent_ and isset _Order column_ - you get functional for reorder with tree view.

![sortt](https://user-images.githubusercontent.com/54917334/71716864-2e15bc00-2e27-11ea-92b6-eea524317c74.PNG)
#
### VoyagerBaseController 
**VoyagerBaseController _order_() updated:**
1. A new code in which, depending on the presence of a column _menu_parent_, new functions are called for constructing templates.
2. Removed the transfer of parameters - _display_column_, _dataRow_ to the view, because the view template has been changed and now does not require these parameters.

**VoyagerBaseController - _order_results_tree_array_() added:**
New recursive function that builds a tree array from resources, which is called in the _order_()

**VoyagerBaseController - _order_results_tree_build_() added:**
New recursive function that builds a view output from view templates, which is called in the _order_()

**VoyagerBaseController - _update_order_() updated:**
1. Fixed a bug. Previously, if descending ordering was assigned, the resources were still updated as ascending, and after refreshing the page we saw this bug.
Therefore, I added a new function _reverseArray_() which reverses the multidimensional array and saves it later as needed.
2. Created a condition and now if the table/model has a '_menu_parent_' column then it calls the new recursive function _update_order_tree_()

**VoyagerBaseController - _reverseArray_() added:**
New function. Used in _update_order_() for reverse multidimensional array.

**VoyagerBaseController - _update_order_tree_() added:**
New Recursive function called in _update_order_() to update tree resources
#
### View Templates

All new and updated view templates called and used as renders in controller.

**_bread/order.blade.php_ updated**
1. Buttons added Collapse all, Expand all if _results_tree_view_ from controller is true.
2. Remove foreach $_results_ and added conditions for $_results_
3. Scripts updated. Added _orderDirection_ as param in ajax request.

**_bread/order-tree-wrapper-without-childs.blade.php_  added**
New view template as Wrapper for results item without childrens (not tree view).

**_bread/order-tree-wrapper-with-childs.blade.php_   added**
New view template as Wrapper for results item with childrens (tree view).

**_order-tree-item.blade.php_  added**
New view template as item of results.

#
Attention to enable functionality in BREAD reorder:
* Column named _menu_parent_ needs in your BREAD
*  _Order column_ must be assigned and not be empty
#

_Dzianis Yaukhuta
dzianisyaukhuta@gmail.com_







