### PR TITLE
WIP - nestable BREAD ordering

### DIFF
--- a/resources/views/bread/order.blade.php
+++ b/resources/views/bread/order.blade.php
@@ -19,23 +19,7 @@
 
                 <div class="panel-body" style="padding:30px;">
                     <div class="dd">
-                        <ol class="dd-list">
-                            @foreach ($results as $result)
-                            <li class="dd-item" data-id="{{ $result->getKey() }}">
-                                <div class="dd-handle" style="height:inherit">
-                                    @if (isset($dataRow->details->view))
-                                        @include($dataRow->details->view, ['row' => $dataRow, 'dataType' => $dataType, 'dataTypeContent' => $result, 'content' => $result->{$display_column}, 'action' => 'order'])
-                                    @elseif($dataRow->type == 'image')
-                                        <span>
-                                            <img src="@if( !filter_var($result->{$display_column}, FILTER_VALIDATE_URL)){{ Voyager::image( $result->{$display_column} ) }}@else{{ $result->{$display_column} }}@endif" style="height:100px">
-                                        </span>
-                                    @else
-                                        <span>{{ $result->{$display_column} }}</span>
-                                    @endif
-                                </div>
-                            </li>
-                            @endforeach
-                        </ol>
+                        @include('voyager::bread.partials.order', ['items' => $results, 'nestable' => $nestable, 'parentId' => ''])
                     </div>
                 </div>
             </div>
@@ -50,7 +34,7 @@
 <script>
 $(document).ready(function () {
     $('.dd').nestable({
-        maxDepth: 1
+        @if(empty($nestable)) maxDepth: 1 @endif
     });
 
     /**

--- a/resources/views/bread/partials/order.blade.php
+++ b/resources/views/bread/partials/order.blade.php
@@ -1,6 +1,6 @@
 <ol class="dd-list">
     @foreach ($items as $result)
-        @if($nestable && $result->parent_id != $parentId)
+        @if(!empty($nestable) && $result->{$result->getParentField()} != $parentId)
             @continue
         @endif
     <li class="dd-item" data-id="{{ $result->getKey() }}">
@@ -15,7 +15,7 @@
                 <span>{{ $result->{$display_column} }}</span>
             @endif
         </div>
-        @if(isset($result->nestableChildren) && !$result->nestableChildren->isEmpty())
+        @if(!empty($nestable) && !$result->nestableChildren->isEmpty())
             @include('voyager::bread.partials.order', ['items' => $result->nestableChildren, 'parentId' => $result->getKey()])
         @endif
     </li>

--- a/resources/views/bread/partials/order.blade.php
+++ b/resources/views/bread/partials/order.blade.php
@@ -1,0 +1,23 @@
+<ol class="dd-list">
+    @foreach ($items as $result)
+        @if($nestable && $result->parent_id != $parentId)
+            @continue
+        @endif
+    <li class="dd-item" data-id="{{ $result->getKey() }}">
+        <div class="dd-handle" style="height:inherit">
+            @if (isset($dataRow->details->view))
+                @include($dataRow->details->view, ['row' => $dataRow, 'dataType' => $dataType, 'dataTypeContent' => $result, 'content' => $result->{$display_column}, 'action' => 'order'])
+            @elseif($dataRow->type == 'image')
+                <span>
+                    <img src="@if( !filter_var($result->{$display_column}, FILTER_VALIDATE_URL)){{ Voyager::image( $result->{$display_column} ) }}@else{{ $result->{$display_column} }}@endif" style="height:100px">
+                </span>
+            @else
+                <span>{{ $result->{$display_column} }}</span>
+            @endif
+        </div>
+        @if(isset($result->nestableChildren) && !$result->nestableChildren->isEmpty())
+            @include('voyager::bread.partials.order', ['items' => $result->nestableChildren, 'parentId' => $result->getKey()])
+        @endif
+    </li>
+    @endforeach
+</ol>

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -14,8 +14,8 @@ use TCG\Voyager\Events\BreadDataRestored;
 use TCG\Voyager\Events\BreadDataUpdated;
 use TCG\Voyager\Events\BreadImagesDeleted;
 use TCG\Voyager\Facades\Voyager;
-use TCG\Voyager\Traits\Nestable;
 use TCG\Voyager\Http\Controllers\Traits\BreadRelationshipParser;
+use TCG\Voyager\Traits\Nestable;
 
 class VoyagerBaseController extends Controller
 {

--- a/src/Traits/Nestable.php
+++ b/src/Traits/Nestable.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace TCG\Voyager\Traits;
+
+use TCG\Voyager\Facades\Voyager;
+
+trait Nestable
+{
+    public function nestableChildren()
+    {
+        $dataType = Voyager::model('DataType')->where('model_name', '=', get_class())->first();
+
+        return $this->hasMany(self::class, $this->parentField)
+                    ->orderBy($dataType->order_column, $dataType->order_direction);
+    }
+
+    public function getParentField()
+    {
+        return $this->parentField;
+    }
+}


### PR DESCRIPTION
Make ordering nestable if Trait is used by Model, Model will need to set parent id field like:
```php
use TCG\Voyager\Traits\Nestable;

class Category extends Model
{
    use Nestable;

    protected $parentField = 'parent_id';
```

Fixes order not mantained while using descending order direction.

Closes #4641

Co-Authored-By: dzianisyaukhuta <dzianisyaukhuta@users.noreply.github.com>