### PR TITLE
Remove Route in InstallCommand

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -107,10 +107,6 @@ class InstallCommand extends Command
             );
         }
 
-        \Route::group(['prefix' => 'admin'], function () {
-            \Voyager::routes();
-        });
-
         $this->info('Seeding data into the database');
         $this->seed('VoyagerDatabaseSeeder');
 


### PR DESCRIPTION
Routes needed to be defined on install for old Voyager versions because MenuItemsTableSeeder used to seed the full url into database.
That's not the case anymore so this can be removed.

This part of code was also causing routes on tests to be  defined in a different order than  normal use because on install Route was called before seeding DataTypes.