### PR TITLE
Fix ordering column

### DIFF
--- a/src/Http/Controllers/Traits/BreadRelationshipParser.php
+++ b/src/Http/Controllers/Traits/BreadRelationshipParser.php
@@ -24,6 +24,9 @@ trait BreadRelationshipParser
         foreach ($forget_keys as $forget_key) {
             $dataType->{$bread_type.'Rows'}->forget($forget_key);
         }
+
+        // Reindex collection
+        $dataType->{$bread_type.'Rows'} = $dataType->{$bread_type.'Rows'}->values();
     }
 
     /**


### PR DESCRIPTION
When there is a belongsTo relationship foreign key field is removed with removeRelationshipField.
When we try to get the $orderColumn we use collection index (VoyagerBaseController.php#⁠L152) that is now skipping a value resulting on wrong or non existent column ordered in datatable.

Example selecting updated_at for users Role is skipped but still counts as index in collection.

![Schermata da 2020-01-14 11-13-43](https://user-images.githubusercontent.com/6875243/72335308-0e9c5000-36bf-11ea-832f-9c6414f4f99e.png)


![Schermata da 2020-01-14 11-12-16](https://user-images.githubusercontent.com/6875243/72335128-c67d2d80-36be-11ea-867b-d5122a931d33.png)


