### PR TITLE
Fix displaying translatable rich text box to consistent with non-translatable

### DIFF
--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -224,7 +224,7 @@
                 _val   = inp.data(lang);
 
             if (!this.settings.editing) {
-                inpUsr.text(_val);
+                inpUsr.html(_val);
 
             } else {
                 var _mce = tinymce.get('richtext'+inpUsr.prop('name'));

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -199,7 +199,7 @@
                                                     @endif
                                                 @elseif($row->type == 'rich_text_box')
                                                     @include('voyager::multilingual.input-hidden-bread-browse')
-                                                    <div>{{ mb_strlen( strip_tags($data->{$row->field}, '<b><i><u>') ) > 200 ? mb_substr(strip_tags($data->{$row->field}, '<b><i><u>'), 0, 200) . ' ...' : strip_tags($data->{$row->field}, '<b><i><u>') }}</div>
+                                                    <div>{{ str_limit_html(strip_tags($data->{$row->field}, '<b><i><u><strong><em><span>'), 200) }}</div>
                                                 @elseif($row->type == 'coordinates')
                                                     @include('voyager::partials.coordinates-static-image')
                                                 @elseif($row->type == 'multiple_images')

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -111,7 +111,7 @@
                                 @include('voyager::partials.coordinates')
                             @elseif($row->type == 'rich_text_box')
                                 @include('voyager::multilingual.input-hidden-bread-read')
-                                {!! $dataTypeContent->{$row->field} !!}
+                                <div>{!! $dataTypeContent->{$row->field} !!}</div>
                             @elseif($row->type == 'file')
                                 @if(json_decode($dataTypeContent->{$row->field}))
                                     @foreach(json_decode($dataTypeContent->{$row->field}) as $file)

--- a/resources/views/multilingual/input-hidden-bread-browse.blade.php
+++ b/resources/views/multilingual/input-hidden-bread-browse.blade.php
@@ -3,5 +3,5 @@
            data-i18n="true"
            name="{{ $row->field.$row->id }}_i18n"
            id="{{ $row->field.$row->id }}_i18n"
-           value="{{ get_field_translations($data, $row->field) }}">
+           value="{{ get_field_translations($data, $row->field, true, '<b><i><u><strong><em><span>', 200) }}">
 @endif

--- a/resources/views/multilingual/input-hidden-bread-read.blade.php
+++ b/resources/views/multilingual/input-hidden-bread-read.blade.php
@@ -3,5 +3,5 @@
            data-i18n="true"
            name="{{ $row->field }}_i18n"
            id="{{ $row->field }}_i18n"
-           value="{{ get_field_translations($dataTypeContent, $row->field, $row->type, true) }}">
+           value="{{ get_field_translations($dataTypeContent, $row->field) }}">
 @endif

--- a/src/Helpers/helperTranslations.php
+++ b/src/Helpers/helperTranslations.php
@@ -25,16 +25,23 @@ if (!function_exists('get_field_translations')) {
      *
      * @param Illuminate\Database\Eloquent\Model $model
      * @param string                             $field
-     * @param string                             $rowType
      * @param bool                               $stripHtmlTags
+     * @param string|null                        $allowableHtmlTags
+     * @param int|null                           $maxLength
      */
-    function get_field_translations($model, $field, $rowType = '', $stripHtmlTags = false)
+    function get_field_translations($model, $field, $stripHtmlTags = false, $allowableHtmlTags = null, $maxLength = null)
     {
         $_out = $model->getTranslationsOf($field);
 
-        if ($stripHtmlTags && $rowType == 'rich_text_box') {
+        if ($stripHtmlTags) {
             foreach ($_out as $language => $value) {
-                $_out[$language] = strip_tags($_out[$language]);
+                $_out[$language] = strip_tags($_out[$language], $allowableHtmlTags ?: null);
+            }
+        }
+
+        if ($maxLength) {
+            foreach ($_out as $language => $value) {
+                $_out[$language] = str_limit_html($_out[$language], $maxLength);
             }
         }
 

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -38,7 +38,7 @@ if (!function_exists('str_limit_html')) {
         // find all tags
         $tagPattern = '/(<\/?)([\w]*)(\s*[^>]*)>?|&[\w#]+;/i';
         // match html tags and entities
-        preg_match_all($tagPattern, $string, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER );
+        preg_match_all($tagPattern, $string, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
         $i = 0;
 
         // loop through each found tag that is within the $length, add those characters to the len,
@@ -60,7 +60,7 @@ if (!function_exists('str_limit_html')) {
             // ignore empty/singleton tags for tag counting
             if (!empty($matches[$i][2][0]) && !in_array($matches[$i][2][0], ['br', 'img', 'hr', 'input', 'param', 'link'])) {
                 // double check
-                if (substr($matches[$i][3][0],-1) !== '/' && substr($matches[$i][1][0],-1) !== '/') {
+                if (substr($matches[$i][3][0], -1) !== '/' && substr($matches[$i][1][0],-1) !== '/') {
                     $openTags[] = $matches[$i][2][0];
                 } elseif (end($openTags) === $matches[$i][2][0]) {
                     array_pop($openTags);
@@ -84,10 +84,12 @@ if (!function_exists('str_limit_html')) {
             $string = mb_substr($string, 0, $length);
             // finds last character
             $last_character = rtrim(mb_substr($string, -1, 1));
-            // add the end text
-            $truncated_html = ($last_character === '.' ? $string : ($last_character === ',' ? mb_substr($string, 0, -1) : $string) . $end);
-            // restore any open tags
-            $truncated_html .= $closeTagString;
+            // trim punctuation
+            if (in_array($last_character, ['.', ','])) {
+                $truncated_html = mb_substr($string, 0, -1);
+            }
+            // add the end text and restore any open tags
+            $truncated_html .= $end . $closeTagString;
         } else {
             $truncated_html = $string;
         }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -34,7 +34,8 @@ if (!function_exists('get_file_name')) {
 }
 
 if (!function_exists('str_limit_html')) {
-    function str_limit_html($string, $length, $end = '&hellip;') {
+    function str_limit_html($string, $length, $end = '&hellip;')
+    {
         // find all tags
         $tagPattern = '/(<\/?)([\w]*)(\s*[^>]*)>?|&[\w#]+;/i';
         // match html tags and entities
@@ -60,7 +61,7 @@ if (!function_exists('str_limit_html')) {
             // ignore empty/singleton tags for tag counting
             if (!empty($matches[$i][2][0]) && !in_array($matches[$i][2][0], ['br', 'img', 'hr', 'input', 'param', 'link'])) {
                 // double check
-                if (substr($matches[$i][3][0], -1) !== '/' && substr($matches[$i][1][0],-1) !== '/') {
+                if (substr($matches[$i][3][0], -1) !== '/' && substr($matches[$i][1][0], -1) !== '/') {
                     $openTags[] = $matches[$i][2][0];
                 } elseif (end($openTags) === $matches[$i][2][0]) {
                     array_pop($openTags);
@@ -89,7 +90,7 @@ if (!function_exists('str_limit_html')) {
                 $truncated_html = mb_substr($string, 0, -1);
             }
             // add the end text and restore any open tags
-            $truncated_html .= $end . $closeTagString;
+            $truncated_html .= $end.$closeTagString;
         } else {
             $truncated_html = $string;
         }

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -84,7 +84,7 @@ if (!function_exists('str_limit_html')) {
             // truncate with new len last word
             $truncated_html = rtrim(mb_substr($string, 0, $length));
             // finds last character
-            $last_character = mb_substr($string, -1, 1);
+            $last_character = mb_substr($truncated_html, -1, 1);
             // trim punctuation
             if (in_array($last_character, ['.', ','])) {
                 $truncated_html = mb_substr($truncated_html, 0, -1);

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -82,9 +82,9 @@ if (!function_exists('str_limit_html')) {
 
         if (mb_strlen($string) > $length) {
             // truncate with new len last word
-            $string = mb_substr($string, 0, $length);
+            $truncated_html = rtrim(mb_substr($string, 0, $length));
             // finds last character
-            $last_character = rtrim(mb_substr($string, -1, 1));
+            $last_character = mb_substr($string, -1, 1);
             // trim punctuation
             if (in_array($last_character, ['.', ','])) {
                 $truncated_html = mb_substr($string, 0, -1);

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -51,7 +51,7 @@ if (!function_exists('str_limit_html')) {
         // $matches[$i][$j][0] = the string
         // $matches[$i][$j][1] = the str offest
         while (!empty($matches[$i]) && $matches[$i][0][1] < $length) {
-            $length = $length + strlen($matches[$i][0][0]);
+            $length = $length + mb_strlen($matches[$i][0][0]);
             if (substr($matches[$i][0][0], 0, 1) === '&') {
                 $length--;
             }
@@ -83,7 +83,7 @@ if (!function_exists('str_limit_html')) {
             // truncate with new len last word
             $string = mb_substr($string, 0, $length);
             // finds last character
-            $last_character = mb_substr($string, -1, 1);
+            $last_character = rtrim(mb_substr($string, -1, 1));
             // add the end text
             $truncated_html = ($last_character === '.' ? $string : ($last_character === ',' ? mb_substr($string, 0, -1) : $string) . $end);
             // restore any open tags

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -87,7 +87,7 @@ if (!function_exists('str_limit_html')) {
             $last_character = mb_substr($string, -1, 1);
             // trim punctuation
             if (in_array($last_character, ['.', ','])) {
-                $truncated_html = mb_substr($string, 0, -1);
+                $truncated_html = mb_substr($truncated_html, 0, -1);
             }
             // add the end text and restore any open tags
             $truncated_html .= $end.$closeTagString;


### PR DESCRIPTION
Updated bread's browse and read views to render in the same way.

Translated rich text on browse now strips most tags on translatable fields and truncates, same as non-translated.

Translated  rich test on read now renders with tags, same as non-translated.

Breaking change (possibly, but unlikely): changed `get_field_translations` parameters.
