### PR TITLE
Intervention from Laravel5 to Laravel Recent

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,7 +71,7 @@ The first thing you should do is publish the assets that come with Voyager. You 
 
 ```bash
 php artisan vendor:publish --provider="TCG\Voyager\VoyagerServiceProvider"
-php artisan vendor:publish --provider="Intervention\Image\ImageServiceProviderLaravel5"
+php artisan vendor:publish --provider="Intervention\Image\ImageServiceProviderLaravelRecent"
 ```
 
 Next, call `php artisan migrate` to migrate all Voyager table.


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/45922630/73127045-a2580100-3f88-11ea-9527-d5014e7f32f7.PNG)

Intervention has updated the ImageServiceProvider from Laravel 5 to LaravelRecent for compatibility with Laravel6
