### PR TITLE
Update roles View and Controller

### DIFF
--- a/resources/views/roles/edit-add.blade.php
+++ b/resources/views/roles/edit-add.blade.php
@@ -1,104 +1,35 @@
-@extends('voyager::master')
-
-@section('page_title', __('voyager::generic.'.(isset($dataTypeContent->id) ? 'edit' : 'add')).' '.$dataType->getTranslatedAttribute('display_name_singular'))
-
-@section('css')
-    <meta name="csrf-token" content="{{ csrf_token() }}">
-@stop
-
-@section('page_header')
-    <h1 class="page-title">
-        <i class="{{ $dataType->icon }}"></i>
-        {{ __('voyager::generic.'.(isset($dataTypeContent->id) ? 'edit' : 'add')).' '.$dataType->getTranslatedAttribute('display_name_singular') }}
-    </h1>
-@stop
+@extends('voyager::bread.edit-add')
 
 @section('content')
-    <div class="page-content container-fluid">
-        @include('voyager::alerts')
-        <div class="row">
-            <div class="col-md-12">
-
-                <div class="panel panel-bordered">
-                    <!-- form start -->
-                    <form class="form-edit-add" role="form"
-                          action="@if(isset($dataTypeContent->id)){{ route('voyager.'.$dataType->slug.'.update', $dataTypeContent->id) }}@else{{ route('voyager.'.$dataType->slug.'.store') }}@endif"
-                          method="POST" enctype="multipart/form-data">
-
-                        <!-- PUT Method if we are editing -->
-                        @if(isset($dataTypeContent->id))
-                            {{ method_field("PUT") }}
-                        @endif
-
-                        <!-- CSRF TOKEN -->
-                        {{ csrf_field() }}
-
-                        <div class="panel-body">
-
-                            @if (count($errors) > 0)
-                                <div class="alert alert-danger">
-                                    <ul>
-                                        @foreach ($errors->all() as $error)
-                                            <li>{{ $error }}</li>
-                                        @endforeach
-                                    </ul>
-                                </div>
-                            @endif
-
-                            @foreach($dataType->addRows as $row)
-                                <div class="form-group">
-                                    <label for="name">{{ $row->getTranslatedAttribute('display_name') }}</label>
-
-                                    {!! Voyager::formField($row, $dataType, $dataTypeContent) !!}
-
-                                </div>
-                            @endforeach
-
-                            <label for="permission">{{ __('voyager::generic.permissions') }}</label><br>
-                            <a href="#" class="permission-select-all">{{ __('voyager::generic.select_all') }}</a> / <a href="#"  class="permission-deselect-all">{{ __('voyager::generic.deselect_all') }}</a>
-                            <ul class="permissions checkbox">
-                                <?php
-                                    $role_permissions = (isset($dataTypeContent)) ? $dataTypeContent->permissions->pluck('key')->toArray() : [];
-                                ?>
-                                @foreach(Voyager::model('Permission')->all()->groupBy('table_name') as $table => $permission)
-                                    <li>
-                                        <input type="checkbox" id="{{$table}}" class="permission-group">
-                                        <label for="{{$table}}"><strong>{{\Illuminate\Support\Str::title(str_replace('_',' ', $table))}}</strong></label>
-                                        <ul>
-                                            @foreach($permission as $perm)
-                                                <li>
-                                                    <input type="checkbox" id="permission-{{$perm->id}}" name="permissions[{{$perm->id}}]" class="the-permission" value="{{$perm->id}}" @if(in_array($perm->key, $role_permissions)) checked @endif>
-                                                    <label for="permission-{{$perm->id}}">{{\Illuminate\Support\Str::title(str_replace('_', ' ', $perm->key))}}</label>
-                                                </li>
-                                            @endforeach
-                                        </ul>
-                                    </li>
-                                @endforeach
-                            </ul>
-                        </div><!-- panel-body -->
-                        <div class="panel-footer">
-                            <button type="submit" class="btn btn-primary">{{ __('voyager::generic.submit') }}</button>
-                        </div>
-                    </form>
-
-                    <iframe id="form_target" name="form_target" style="display:none"></iframe>
-                    <form id="my_form" action="{{ route('voyager.upload') }}" target="form_target" method="post"
-                          enctype="multipart/form-data" style="width:0;height:0;overflow:hidden">
-                        {{ csrf_field() }}
-                        <input name="image" id="upload_file" type="file"
-                               onchange="$('#my_form').submit();this.value='';">
-                        <input type="hidden" name="type_slug" id="type_slug" value="{{ $dataType->slug }}">
-                    </form>
-
-                </div>
-            </div>
-        </div>
+    @parent
+    <div class="form-group col-md-12" id="permissions">
+        <label for="permission">{{ __('voyager::generic.permissions') }}</label><br>
+        <a href="#" class="permission-select-all">{{ __('voyager::generic.select_all') }}</a> / <a href="#"  class="permission-deselect-all">{{ __('voyager::generic.deselect_all') }}</a>
+        <ul class="permissions checkbox">
+            @foreach($permissions as $table => $permission)
+                <li>
+                    <input type="checkbox" id="{{$table}}" class="permission-group">
+                    <label for="{{$table}}"><strong>{{\Illuminate\Support\Str::title(str_replace('_',' ', $table))}}</strong></label>
+                    <ul>
+                        @foreach($permission as $perm)
+                            <li>
+                                <input type="checkbox" id="permission-{{$perm->id}}" name="permissions[{{$perm->id}}]" class="the-permission" value="{{$perm->id}}" @if(in_array($perm->key, $rolePermissions)) checked @endif>
+                                <label for="permission-{{$perm->id}}">{{\Illuminate\Support\Str::title(str_replace('_', ' ', $perm->key))}}</label>
+                            </li>
+                        @endforeach
+                    </ul>
+                </li>
+            @endforeach
+        </ul>
     </div>
 @stop
 
 @section('javascript')
+    @parent
     <script>
         $('document').ready(function () {
+            $("#permissions").appendTo("form.form-edit-add .panel-body");
+
             $('.toggleswitch').bootstrapToggle();
 
             $('.permission-group').on('change', function(){

--- a/src/Http/Controllers/VoyagerRoleController.php
+++ b/src/Http/Controllers/VoyagerRoleController.php
@@ -8,6 +8,22 @@ use TCG\Voyager\Facades\Voyager;
 class VoyagerRoleController extends VoyagerBaseController
 {
     // POST BR(E)AD
+    public function edit(Request $request, $id)
+    {
+        $view = parent::edit($request, $id);
+
+        return $this->addPermissionList($view);
+    }
+
+    // POST BRE(A)D
+    public function create(Request $request)
+    {
+        $view = parent::create($request);
+
+        return $this->addPermissionList($view);
+    }
+
+    // POST BR(E)AD
     public function update(Request $request, $id)
     {
         $slug = $this->getSlug($request);
@@ -57,5 +73,16 @@ class VoyagerRoleController extends VoyagerBaseController
                 'message'    => __('voyager::generic.successfully_added_new')." {$dataType->getTranslatedAttribute('display_name_singular')}",
                 'alert-type' => 'success',
             ]);
+    }
+
+    // Passes all permissions and rolePermissions to the view
+    protected function addPermissionList($view)
+    {
+        if ($view instanceof \Illuminate\View\View) {
+            $view->permissions = Voyager::model('Permission')->all()->groupBy('table_name');
+            $view->rolePermissions = $view->dataTypeContent->permissions->pluck('key')->toArray() ?? [];
+        }
+
+        return $view;
     }
 }

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -71,7 +71,7 @@ class RolesTest extends TestCase
 
         $this->visit(route('voyager.roles.edit', 2))
              ->uncheck('permissions['.$this->permission_id.']')
-             ->press(__('voyager::generic.submit'))
+             ->press(__('voyager::generic.save'))
              ->seePageIs(route('voyager.roles.index'))
              ->notSeeInDatabase('permission_role', ['permission_id' => $this->permission_id, 'role_id' => 2]);
     }

--- a/tests/RolesTest.php
+++ b/tests/RolesTest.php
@@ -32,21 +32,21 @@ class RolesTest extends TestCase
         $this->visit(route('voyager.roles.create'))
              ->type('superadmin', 'name')
              ->type('Super Admin', 'display_name')
-             ->press(__('voyager::generic.submit'))
+             ->press(__('voyager::generic.save'))
              ->seePageIs(route('voyager.roles.index'))
              ->seeInDatabase('roles', ['name' => 'superadmin']);
 
         // Editing a Role
         $this->visit(route('voyager.roles.edit', 2))
              ->type('regular_user', 'name')
-             ->press(__('voyager::generic.submit'))
+             ->press(__('voyager::generic.save'))
              ->seePageIs(route('voyager.roles.index'))
              ->seeInDatabase('roles', ['name' => 'regular_user']);
 
         // Editing a Role
         $this->visit(route('voyager.roles.edit', 2))
              ->type('user', 'name')
-             ->press(__('voyager::generic.submit'))
+             ->press(__('voyager::generic.save'))
              ->seePageIs(route('voyager.roles.index'))
              ->seeInDatabase('roles', ['name' => 'user']);
 


### PR DESCRIPTION
Roles has a custom edit-add view and Controller, this makes it harder to mantain since most of the view is copied and some part is missing like showing relationships.

My PR introduces another way to override add-edit template without copying the original content but only adding changes.

More in details roles need permission list with checkboxes, html part is added at the end of content and moved in the right place with javascript.

I also moved queries done in template to retrieve permissions to the Controller.

Fixes #4754