### PR TITLE
Fixes Language picker not displayed on browse

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -112,7 +112,7 @@ class VoyagerBaseController extends Controller
         }
 
         // Check if BREAD is Translatable
-        $isModelTranslatable = is_bread_translatable($dataTypeContent);
+        $isModelTranslatable = is_bread_translatable($model);
 
         // Eagerload Relations
         $this->eagerLoadRelations($dataTypeContent, $dataType, 'browse', $isModelTranslatable);


### PR DESCRIPTION
Fixes a mistake in #4719

`is_bread_translatable` doesn't work on collections, that's why `$model` was used.

