### PR TITLE
Fix removed routes names in #4826

### DIFF
--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -288,7 +288,7 @@
              * Reorder items
              */
             $('.dd').on('change', function (e) {
-                $.post('{{ route('voyager.menus.order',['menu' => $menu->id]) }}', {
+                $.post('{{ route('voyager.menus.order_item',['menu' => $menu->id]) }}', {
                     order: JSON.stringify($('.dd').nestable('serialize')),
                     _token: '{{ csrf_token() }}'
                 }, function (data) {

--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -43,7 +43,7 @@ Route::group(['as' => 'voyager.'], function () {
 
                 Route::get($dataType->slug.'/order', $breadController.'@order')->name($dataType->slug.'.order');
                 Route::post($dataType->slug.'/action', $breadController.'@action')->name($dataType->slug.'.action');
-                Route::post($dataType->slug.'/order', $breadController.'@update_order');
+                Route::post($dataType->slug.'/order', $breadController.'@update_order')->name($dataType->slug.'.update_order');;
                 Route::get($dataType->slug.'/{id}/restore', $breadController.'@restore')->name($dataType->slug.'.restore');
                 Route::get($dataType->slug.'/relation', $breadController.'@relation')->name($dataType->slug.'.relation');
                 Route::post($dataType->slug.'/remove', $breadController.'@remove_media')->name($dataType->slug.'.media.remove');
@@ -61,7 +61,7 @@ Route::group(['as' => 'voyager.'], function () {
             'prefix' => 'menus/{menu}',
         ], function () use ($namespacePrefix) {
             Route::get('builder', ['uses' => $namespacePrefix.'VoyagerMenuController@builder',    'as' => 'builder']);
-            Route::post('order', ['uses' => $namespacePrefix.'VoyagerMenuController@order_item']);
+            Route::post('order', ['uses' => $namespacePrefix.'VoyagerMenuController@order_item', 'as' => 'order_item']);
 
             Route::group([
                 'as'     => 'item.',


### PR DESCRIPTION
Reintroduced route names that are needed to find slug.
menus/builder.blade needs to reference the new route name because it's different while bread/order.blade generated url is the same.

Partially reverts my commits in #4826

Co-Authored-By: Ahmet Bedir <ahmetbedir@users.noreply.github.com>