### PR TITLE
Scope relationship options

### DIFF
--- a/docs/bread/relationships.md
+++ b/docs/bread/relationships.md
@@ -1,5 +1,7 @@
 # Relationships
 
+## Adding a relationship
+
 Using the BREAD builder you can easily create Relationships between tables. At the bottom of the page you will see a new button that says 'Create Relationship'
 
 ![](../.gitbook/assets/bread_relationship.png)
@@ -21,6 +23,8 @@ You can also specify which columns you would like to see in the dropdown or the 
 
 Now, you can easily create `belongsTo`, `belongsToMany`, `hasOne`, and `hasMany` relationships directly in Voyager.
 
+## Advanced options
+
 If you need to set advanced options for `belongsToMany` relationship you can set, after saving relationship, these parameters in details field:
 
 ```php
@@ -30,3 +34,26 @@ If you need to set advanced options for `belongsToMany` relationship you can set
     "related_key": "id"
 }
 ```
+
+## Scoping relationships
+
+You can easily filter the showns relationship option by defining a [local scope](https://laravel.com/docs/eloquent#local-scopes) in the foreign model.  
+For example, if you want to only show active entries, create a scope like:
+
+```php
+public function scopeActive($query)
+{
+    return $query->where('active', 1);
+}
+```
+
+And add the following to the relationship options:
+
+```php
+{
+    "scope": "active",
+}
+```
+
+The value is the name of your scope-method without scope.  
+The value for `scopeActive()` is `active`. For `scopeSomeUsers()` it is `someUsers`.

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -856,6 +856,11 @@ class VoyagerBaseController extends Controller
                 $model = app($options->model);
                 $skip = $on_page * ($page - 1);
 
+                // Apply local scope if it is defined in the relationship-options
+                if ($options->scope && $options->scope != '' && method_exists($model, 'scope'.ucfirst($options->scope))) {
+                    $model = $model->{$options->scope}();
+                }
+
                 // If search query, use LIKE to filter results depending on field label
                 if ($search) {
                     // If we are using additional_attribute as label


### PR DESCRIPTION
This allows to use a local scope on the related model in a relationship.

**Usage:**
Create a scope, for example
```
public function scopeActive($query)
{
    return $query->where('active', 1);
}
```

and add to the relationship options:

```
{
    "scope": "active"
}
```


Supersedes #4760