### PR TITLE
Prevent filtered records being updateable

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -317,7 +317,7 @@ class VoyagerBaseController extends Controller
         if ($model && in_array(SoftDeletes::class, class_uses_recursive($model))) {
             $data = $model->withTrashed()->findOrFail($id);
         } else {
-            $data = call_user_func([$dataType->model_name, 'findOrFail'], $id);
+            $data = $model->findOrFail($id);
         }
 
         // Check permission


### PR DESCRIPTION
A record that **can not** be seen when browsing/editing/reading because of a scope filtering it out **can be** updated when the ID in the request is manipulated.

This PR fixes this.