### PR TITLE
Replace simplemde with easymde

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2107,11 +2107,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "codemirror": {
-      "version": "5.48.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.48.2.tgz",
-      "integrity": "sha512-i9VsmC8AfA5ji6EDIZ+aoSe4vt9FcwPLdHB1k1ItFbVyuOFRrcfvnoKqwZlC7EVA2UmTRiNEypE4Uo7YvzVY8Q=="
-    },
     "codemirror-spell-checker": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/codemirror-spell-checker/-/codemirror-spell-checker-1.1.2.tgz",
@@ -3160,6 +3155,28 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
+      }
+    },
+    "easymde": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/easymde/-/easymde-2.10.0.tgz",
+      "integrity": "sha512-0xq5BRedHLg0nUJoR4pERPwoXFvimeutjyA+GFVd6T16sqNO9A2yGwK1jyY0gdwJBbbHLvDg6jneYO/7ef3rvg==",
+      "requires": {
+        "codemirror": "^5.52.2",
+        "codemirror-spell-checker": "1.1.2",
+        "marked": "^0.8.2"
+      },
+      "dependencies": {
+        "codemirror": {
+          "version": "5.52.2",
+          "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.52.2.tgz",
+          "integrity": "sha512-WCGCixNUck2HGvY8/ZNI1jYfxPG5cRHv0VjmWuNzbtCLz8qYA5d+je4QhSSCtCaagyeOwMi/HmmPTjBgiTm2lQ=="
+        },
+        "marked": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+          "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+        }
       }
     },
     "ecc-jsbn": {
@@ -6099,11 +6116,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
-    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -8797,16 +8809,6 @@
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
         }
-      }
-    },
-    "simplemde": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/simplemde/-/simplemde-1.11.2.tgz",
-      "integrity": "sha1-ojo12XjSxA7wfewAjJLwcNjggOM=",
-      "requires": {
-        "codemirror": "*",
-        "codemirror-spell-checker": "*",
-        "marked": "*"
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "datatables.net": "^1.10.20",
     "datetimepicker": "^0.1.38",
     "dropzone": "^5.0.1",
+    "easymde": "^2.10.0",
     "eonasdan-bootstrap-datetimepicker": "^4.17.47",
     "icheck": "^1.0.2",
     "jquery-match-height": "^0.7.2",
@@ -38,7 +39,6 @@
     "node-sass": "^4.13.1",
     "perfect-scrollbar": "^0.7.1",
     "select2": "^4.0.11",
-    "simplemde": "^1.11.2",
     "tinymce": "^4.9.7",
     "toastr": "^2.1.2",
     "vue": "^2.3.4"

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -6,7 +6,7 @@ window.Cropper = 'default' in window.Cropper ? window.Cropper['default'] : windo
 window.toastr = require('toastr');
 window.DataTable = require('datatables');
 require('datatables-bootstrap3-plugin/media/js/datatables-bootstrap3');
-window.SimpleMDE = require('simplemde');
+window.EasyMDE = require('easymde');
 require('dropzone');
 require('jquery-match-height');
 require('bootstrap-toggle');
@@ -194,11 +194,11 @@ $(document).ready(function () {
 
     /********** MARKDOWN EDITOR **********/
 
-    $('textarea.simplemde').each(function () {
-        var simplemde = new SimpleMDE({
-            element: this,
+    $('textarea.easymde').each(function () {
+        var easymde = new EasyMDE({
+            element: this
         });
-        simplemde.render();
+        easymde.render();
     });
 
     /********** END MARKDOWN EDITOR **********/

--- a/resources/assets/js/multilingual.js
+++ b/resources/assets/js/multilingual.js
@@ -201,10 +201,10 @@
                 $_val = $_mce.getContent();
             }
 
-            if (inpUsr.hasClass('simplemde')) {                                          
-                var $codemirror = inpUsr.nextAll('.CodeMirror')[0].CodeMirror;           
-                $_val = $codemirror.getDoc().getValue();                                 
-                $codemirror.save();                                                      
+            if (inpUsr.hasClass('easymde')) {
+                var $codemirror = inpUsr.nextAll('.CodeMirror')[0].CodeMirror;
+                $_val = $codemirror.getDoc().getValue();
+                $codemirror.save();
             }
 
             this.langSelectors.each(function(i, btn) {
@@ -232,7 +232,7 @@
                     _mce.setContent(_val);
                 } else {
                     inpUsr.val(_val);
-                    if (inpUsr.hasClass('simplemde')) {
+                    if (inpUsr.hasClass('easymde')) {
                         var $codemirror = inpUsr.nextAll('.CodeMirror')[0].CodeMirror;
                         $codemirror.getDoc().setValue(inpUsr.val());
                     }

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -10,7 +10,7 @@
 @import "node_modules/bootstrap-toggle/css/bootstrap-toggle";
 @import "node_modules/icheck/skins/flat/flat";
 @import "node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker";
-@import "node_modules/simplemde/dist/simplemde.min";
+@import "node_modules/easymde/dist/easymde.min";
 @import "node_modules/dropzone/dist/dropzone";
 @import "node_modules/cropperjs/dist/cropper";
 @import "node_modules/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker";

--- a/resources/views/formfields/markdown_editor.blade.php
+++ b/resources/views/formfields/markdown_editor.blade.php
@@ -1,1 +1,1 @@
-<textarea class="form-control simplemde" name="{{ $row->field }}" id="markdown{{ $row->field }}">{{ old($row->field, $dataTypeContent->{$row->field} ?? '') }}</textarea>
+<textarea class="form-control easymde" name="{{ $row->field }}" id="markdown{{ $row->field }}">{{ old($row->field, $dataTypeContent->{$row->field} ?? '') }}</textarea>


### PR DESCRIPTION
Replaces simplemde with [easymde](https://github.com/Ionaru/easy-markdown-editor), a much more maintained and feature-rich markdown editor.
This is just a fork of simplemde so it is completely compatible.

Tested both as a translatable and non-translatable formfield.