### PR TITLE
Fix additional attribute not listed

### DIFF
--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -614,10 +614,7 @@
                     var selected_value = $(this).data('selected');
 
                     var options = $.map(data, function (obj, key) {
-                        obj.id = key;
-                        obj.text = key; 
-
-                        return obj;
+                        return {id: key, text: key};
                     });
 
                     $(this).empty().select2({


### PR DESCRIPTION
Additional attribute is not an object like other table columns.

![Schermata da 2020-04-13 12-36-37](https://user-images.githubusercontent.com/6875243/79114395-76783a80-7d83-11ea-8a09-3aa844d7c7fb.png)

Fixes #4882

Co-Authored-By: tjebe <tjebe@users.noreply.github.com>