### PR TITLE
Fix validation for array elements

### DIFF
--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Support\Facades\Storage;
 use TCG\Voyager\Events\FileDeleted;
@@ -204,7 +205,11 @@ abstract class Controller extends BaseController
             if (!empty($field->display_name)) {
                 if (!empty($data[$fieldName]) && is_array($data[$fieldName])) {
                     foreach ($data[$fieldName] as $index => $element) {
-                        $name = $element->getClientOriginalName() ?? $index + 1;
+                        if ($element instanceof UploadedFile) {
+                            $name = $element->getClientOriginalName();
+                        } else {
+                            $name = $index + 1;
+                        }
 
                         $customAttributes[$fieldName.'.'.$index] = $field->getTranslatedAttribute('display_name').' '.$name;
                     }


### PR DESCRIPTION
Fixes validation when array does not contain files, ex. belongsToMany relationship.

```
Symfony\Component\Debug\Exception\FatalThrowableError
Call to a member function getClientOriginalName() on string
```