### PR TITLE
Bump jquery from 3.5.0 to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5647,9 +5647,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "jquery-match-height": {
       "version": "0.7.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "bootstrap-sass": "^3.3.7",
     "cross-env": "^3.2.3",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "laravel-mix": "^4.1.4",
     "lodash": "^4.17.4",
     "sass-loader": "^7.3.1",


### PR DESCRIPTION
Fixed bug in 3.5.0, trying to open a nested menù throw an error:
Uncaught TypeError: Cannot convert object to primitive value