### PR TITLE
Fix filter null values when array does not start with 0

### DIFF
--- a/src/Http/Controllers/ContentTypes/Relationship.php
+++ b/src/Http/Controllers/ContentTypes/Relationship.php
@@ -11,11 +11,9 @@ class Relationship extends BaseType
     {
         $content = $this->request->input($this->row->field);
         if (is_array($content)) {
-            for ($i = 0; $i < count($content); $i++) {
-                if ($content[$i] === null) {
-                    unset($content[$i]);
-                }
-            }
+            $content = array_filter($content, function ($value) {
+                return $value !== null;
+            });
         }
 
         return $content;


### PR DESCRIPTION
#3350 assumes arrays always starts with 0 and are ordered but this is not true for custom selects that might pass additional data for pivot tables like this:
```php
[
    120 => ["order" => 1].
    240 => ["order" => 2],
]
```

That kind of data caused:
```
ErrorException
Undefined offset: 0
```

To be honest I cannot replicate at all the problem that #3350 PR was solving even totally removing the code, but I only changed it because it might happen in some occasion that I'm unable to reproduce.