### PR TITLE
Fix picking media not updating thumbnails

### DIFF
--- a/resources/views/media/manager.blade.php
+++ b/resources/views/media/manager.blade.php
@@ -540,7 +540,7 @@
             fileIs: function(file, type) {
                 if (typeof file === 'string') {
                     if (type == 'image') {
-                        return this.endsWithAny(['jpg', 'jpeg', 'png', 'bmp'], file);
+                        return this.endsWithAny(['jpg', 'jpeg', 'png', 'bmp'], file.toLowerCase());
                     }
                     //Todo: add other types
                 } else {
@@ -609,9 +609,9 @@
                         } else {
                             content.push(file.relative_path);
                             this.hidden_element.value = JSON.stringify(content);
-                            this.$forceUpdate();
                         }
                     }
+                    this.$forceUpdate();
                 }
             },
             removeFileFromInput: function(path) {


### PR DESCRIPTION
When a file was double-click to pick it, the UI didn't refresh.
This fixes it.
Also fixed a problem where images weren't displayed when the extension was uppercase (ex. `myfile.JPG`)

Fixes https://github.com/the-control-group/voyager/issues/4969