### PR TITLE
Enable breadcrumbs translation

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -19,12 +19,14 @@
                     @foreach ($segments as $segment)
                         @php
                         $url .= '/'.$segment;
+                        $segment = urldecode($segment);
+                        $segment = \Illuminate\Support\Facades\Lang::has('voyager::breadcrumbs.'.$segment) ? __('voyager::breadcrumbs.'.$segment) : ucfirst($segment);
                         @endphp
                         @if ($loop->last)
-                            <li>{{ ucfirst(urldecode($segment)) }}</li>
+                            <li>{{ $segment }}</li>
                         @else
                             <li>
-                                <a href="{{ $url }}">{{ ucfirst(urldecode($segment)) }}</a>
+                                <a href="{{ $url }}">{{ $segment }}</a>
                             </li>
                         @endif
                     @endforeach


### PR DESCRIPTION
It checks if translation is available otherwise it falls back to current value.

The other way to achieve this is to override `breadcrumbs` section but there is no easy way of doing that for all pages without copying all `navbar` template content.

Example:
```php
<?php
// resources/lang/vendor/voyager/en/breadcrumbs.php

return [

    'users' => 'Better Name',

];
```

I was already using this and since I saw someone asking how to do it in Slack I decided to propose it as PR.

@fletch3555 @emptynick let me know if you think it can be merged I'll add documentation somewhere.