### PR TITLE
Fixes issue with NULL primary keys

### DIFF
--- a/src/Actions/EditAction.php
+++ b/src/Actions/EditAction.php
@@ -28,6 +28,12 @@ class EditAction extends AbstractAction
 
     public function getDefaultRoute()
     {
-        return route('voyager.'.$this->dataType->slug.'.edit', $this->data->{$this->data->getKeyName()});
+        $id = $this->data->{$this->data->getKeyName()};
+
+        if (is_null($id)) {
+            throw new \RuntimeException('Primary key in ' . $this->dataType->model_name . ' CANNOT BE null');
+        }
+        
+        return route('voyager.'.$this->dataType->slug.'.edit', $id);
     }
 }

--- a/src/Actions/ViewAction.php
+++ b/src/Actions/ViewAction.php
@@ -28,6 +28,12 @@ class ViewAction extends AbstractAction
 
     public function getDefaultRoute()
     {
-        return route('voyager.'.$this->dataType->slug.'.show', $this->data->{$this->data->getKeyName()});
+        $id = $this->data->{$this->data->getKeyName()};
+
+        if (is_null($id)) {
+            throw new \RuntimeException('Primary key in ' . $this->dataType->model_name . ' CANNOT BE null');
+        }
+
+        return route('voyager.' . $this->dataType->slug . '.show', $id);
     }
 }


### PR DESCRIPTION
When a primary key column has a value set to NULL, Voyager throws an unrelated exception message i.e. Missing required parameters for [Route: voyager.bread.show] [URI: admin/bread/{id}] 

This fix will throw a helpful message pointing the user into the right direction