### PR TITLE
Fix SQL Issue with multiple orderBy('order')

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -55,7 +55,9 @@ class Menu extends Model
         // GET THE MENU - sort collection in blade
         $menu = \Cache::remember('voyager_menu_'.$menuName, \Carbon\Carbon::now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
-            ->with(['parent_items.children'])
+            ->with(['parent_items.children' => function ($q) {
+                $q->orderBy('order');
+            }])
             ->first();
         });
 

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -55,9 +55,7 @@ class Menu extends Model
         // GET THE MENU - sort collection in blade
         $menu = \Cache::remember('voyager_menu_'.$menuName, \Carbon\Carbon::now()->addDays(30), function () use ($menuName) {
             return static::where('name', '=', $menuName)
-            ->with(['parent_items.children' => function ($q) {
-                $q->orderBy('order');
-            }])
+            ->with(['parent_items.children'])
             ->first();
         });
 

--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -41,8 +41,7 @@ class MenuItem extends Model
     public function children()
     {
         return $this->hasMany(Voyager::modelClass('MenuItem'), 'parent_id')
-            ->with('children')
-            ->orderBy('order');
+            ->with('children');
     }
 
     public function menu()


### PR DESCRIPTION
Fixing SQL Issue: A column has been specified more than once in the order by list. Columns in the order by list must be unique.

Just had this issue on a MsSQL server. Whenever the menu items should be shown, I was facing the error from above. And I figured out, that there is indeed the `orderBy('order')` applied multiple times: Once in `Menu::display()` and the other time in the relationship itself, on `MenuItem::children`. 

Since I think it makes somehow sense to sort the MenuItems per default, I decided to remove the `orderBy` in the `Menu::display` method. But this MR is just to share the awareness of the issue, so feel free to do something else to fix the issue 😉

Have a great day! 😁