### PR TITLE
Allow thumbnails in BREAD Image to fit using the position option

### DIFF
--- a/docs/bread/formfields/images.md
+++ b/docs/bread/formfields/images.md
@@ -21,7 +21,8 @@
             "name": "cropped",
             "crop": {
                 "width": "300",
-                "height": "250"
+                "height": "250",
+                "position": "center" // Optional. Refer to http://image.intervention.io/api/fit
             }
         }
     ]
@@ -36,4 +37,4 @@ The image input has many options. By default if you do not specify any options n
 
 **upsize** This is only valid if you have set your image to be resized. If you specify your image to resized to 1000 pixels and the image is smaller than 1000 pixels by default it will not upsize that image to the 1000 pixels; however, if you set `upsize` to true. It will upsize all images to your specified resize values.
 
-**thumbnails** Thumbnails takes an array of objects. Each object is a new thumbnail that is created. Each object contains 2 values, the `name` and `scale` percentage. The `name` will be attached to your thumbnail image \(as an example say the image you uploaded was ABC.jpg a thumbnail with the `name` of `medium` would now be created at ABC-medium.jpg\). The `scale` is the percentage amount you want that thumbnail to scale. This value will be a percentage of the _resize_ width and height if specified.
+**thumbnails** Thumbnails takes an array of objects. Each object is a new thumbnail that is created. Each object contains 2 values, the `name` and `scale` percentage. The `name` will be attached to your thumbnail image \(as an example say the image you uploaded was ABC.jpg a thumbnail with the `name` of `medium` would now be created at ABC-medium.jpg\). The `scale` is the percentage amount you want that thumbnail to scale. This value will be a percentage of the _resize_ width and height if specified. You can fit the thumbnail using the width, height and position specified within the key `crop`.

--- a/src/Http/Controllers/ContentTypes/Image.php
+++ b/src/Http/Controllers/ContentTypes/Image.php
@@ -91,7 +91,7 @@ class Image extends BaseType
                         $crop_height = $thumbnails->crop->height;
                         $image = InterventionImage::make($file)
                             ->orientate()
-                            ->fit($crop_width, $crop_height)
+                            ->fit($crop_width, $crop_height, null, $thumbnails->crop->position ?? 'center')
                             ->encode($file->getClientOriginalExtension(), $resize_quality);
                     }
 

--- a/src/Http/Controllers/ContentTypes/MultipleImage.php
+++ b/src/Http/Controllers/ContentTypes/MultipleImage.php
@@ -97,7 +97,7 @@ class MultipleImage extends BaseType
                         $crop_height = $thumbnails->crop->height;
                         $image = InterventionImage::make($file)
                             ->orientate()
-                            ->fit($crop_width, $crop_height)
+                            ->fit($crop_width, $crop_height, null, $thumbnails->crop->position ?? 'center')
                             ->encode($file->getClientOriginalExtension(), $resize_quality);
                     }
 


### PR DESCRIPTION
When using the "crop" option in a BREAD Image FormField it actually uses the Intervention fit method but only using the width and height options.

This PR will allow the user to define the `position` of the [fit](http://image.intervention.io/api/fit) with this options:

```JSON
{
    "thumbnails": [
        {
            "name": "cropped",
            "crop": {
                "width": "350",
                "height": "250",
                "position": "top-left" 
            }
        }
    ]
}
```