### PR TITLE
Add a clickable label to multiple checkbox

### DIFF
--- a/resources/views/formfields/multiple_checkbox.blade.php
+++ b/resources/views/formfields/multiple_checkbox.blade.php
@@ -12,10 +12,7 @@
             <?php $checked = isset($options->checked) && $options->checked ? true : false; ?>
         @endif
 
-        <input type="checkbox" name="{{ $row->field }}[{{$key}}]"
-        {!! $checked ? 'checked="checked"' : '' !!} value="{{$key}}" 
-        id="{{$key}}"/>
-        {{-- i modified the checkbox and added a label so the user can click the label and have the input checked --}}
+        <input type="checkbox" name="{{ $row->field }}[{{$key}}]" {!! $checked ? 'checked="checked"' : '' !!} value="{{$key}}" id="{{$key}}"/>
         <label for="{{$key}}">{{$label}}</label>
     @endforeach
 @endif

--- a/resources/views/formfields/multiple_checkbox.blade.php
+++ b/resources/views/formfields/multiple_checkbox.blade.php
@@ -13,7 +13,9 @@
         @endif
 
         <input type="checkbox" name="{{ $row->field }}[{{$key}}]"
-               {!! $checked ? 'checked="checked"' : '' !!} value="{{$key}}" />
-        {{$label}}
+        {!! $checked ? 'checked="checked"' : '' !!} value="{{$key}}" 
+        id="{{$key}}"/>
+        {{-- i modified the checkbox and added a label so the user can click the label and have the input checked --}}
+        <label for="{{$key}}">{{$label}}</label>
     @endforeach
 @endif


### PR DESCRIPTION
The multiple checkbox option in the BREAD does not have a label, so if the user will click the name next to the checkbox, it will not be checked,  so I added a label to it so the whole thing is clickable, it's much user-friendly.

you can add more styling to it so it will get more spacing between each checkbox.