### PR TITLE
Menu model display method override bugfix

### DIFF
--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -105,7 +105,7 @@ class Menu extends Model
         \Cache::forget('voyager_menu_'.$this->name);
     }
 
-    private static function processItems($items)
+    protected static function processItems($items)
     {
         // Eagerload Translations
         if (config('voyager.multilingual.enabled')) {


### PR DESCRIPTION
Hello.

In the Voyager [docs](https://voyager-docs.devdojo.com/customization/overriding-files) it is a great example on how to override Voyager models. Unfortunately, Menu::processItems() method was made private, so the only way to override Menu->display() method is to copy-paste Menu::processItems() into the new class.

This commit makes Menu::processItems() method protected.