### PR TITLE
Fix multiple coordinates fields not working

### DIFF
--- a/resources/views/formfields/coordinates.blade.php
+++ b/resources/views/formfields/coordinates.blade.php
@@ -12,7 +12,7 @@
     $showLatLng = $showLatLng ? 'true' : 'false';
 @endphp
 
-<div id="coordinates-formfield">
+<div id="coordinates-formfield-{{ $row->field }}">
     <coordinates
         inline-template
         ref="coordinates"
@@ -107,8 +107,13 @@
             },
             mounted() {
                 // Load Google Maps script
+                const apiUrl = 'https://maps.googleapis.com/maps/api/js?key='+this.apiKey+'&callback=gMapVm.$refs.coordinates.initMap&libraries=places';
+                if (document.querySelectorAll('[src="' + apiUrl + '"]').length > 0) {
+                    return;
+                }
+
                 let gMapScript = document.createElement('script');
-                gMapScript.setAttribute('src', 'https://maps.googleapis.com/maps/api/js?key='+this.apiKey+'&callback=gMapVm.$refs.coordinates.initMap&libraries=places');
+                gMapScript.setAttribute('src', apiUrl);
                 document.head.appendChild(gMapScript);
             },
             methods: {
@@ -202,6 +207,6 @@
             }
         });
 
-        var gMapVm = new Vue({ el: '#coordinates-formfield' });
+        var gMapVm = new Vue({ el: '#coordinates-formfield-{{ $row->field }}' });
     </script>
 @endpush


### PR DESCRIPTION
Only one coordinate field could work in one BREAD because of hardcoded id, also added check to avoid loading library if already loaded.

Fixes #5031

~Since I don't have working API keys I'm waiting for confirmation that it actually works but I don't see other errors in console so it should.~
Only first one is working because we can't use callback to initialize more than one field.