### PR TITLE
Fix compass links relative

### DIFF
--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -94,7 +94,7 @@
                             <textarea rows="3" class="form-control" id="m_parameters" name="parameters" placeholder="{{ json_encode(['key' => 'value'], JSON_PRETTY_PRINT) }}"></textarea><br>
                         </div>
                         <label for="icon_class">{{ __('voyager::menu_builder.icon_class') }} <a
-                                    href="{{ route('voyager.compass.index', [], false) }}#fonts"
+                                    href="{{ route('voyager.compass.index') }}#fonts"
                                     target="_blank">{!! __('voyager::menu_builder.icon_class2') !!}</label>
                         <input type="text" class="form-control" id="m_icon_class" name="icon_class"
                                placeholder="{{ __('voyager::menu_builder.icon_class_ph') }}"><br>

--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -126,7 +126,7 @@
                                 </div>
                                 <div class="col-md-6 form-group">
                                     <label for="icon">{{ __('voyager::bread.icon_hint') }} <a
-                                                href="{{ route('voyager.compass.index', [], false) }}#fonts"
+                                                href="{{ route('voyager.compass.index') }}#fonts"
                                                 target="_blank">{{ __('voyager::bread.icon_hint2') }}</a></label>
                                     <input type="text" class="form-control" name="icon"
                                            placeholder="{{ __('voyager::bread.icon_class') }}"


### PR DESCRIPTION
Some links to compass#fonts are relative, breaking if Voyager is installed in a subfolder.