### PR TITLE
Allow scopes to be dynamic if parameters are defined by the controller

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -71,7 +71,12 @@ class VoyagerBaseController extends Controller
             $model = app($dataType->model_name);
 
             if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-                $query = $model->{$dataType->scope}();
+                $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+                if (method_exists($this, $scopeParamsMethod)) {
+                    $query = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+                } else {
+                    $query = $model->{$dataType->scope}();
+                }
             } else {
                 $query = $model::select('*');
             }
@@ -210,7 +215,12 @@ class VoyagerBaseController extends Controller
                 $model = $model->withTrashed();
             }
             if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-                $model = $model->{$dataType->scope}();
+                $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+                if (method_exists($this, $scopeParamsMethod)) {
+                    $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+                } else {
+                    $model = $model->{$dataType->scope}();
+                }
             }
             $dataTypeContent = call_user_func([$model, 'findOrFail'], $id);
             if ($dataTypeContent->deleted_at) {
@@ -271,7 +281,12 @@ class VoyagerBaseController extends Controller
                 $model = $model->withTrashed();
             }
             if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-                $model = $model->{$dataType->scope}();
+                $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+                if (method_exists($this, $scopeParamsMethod)) {
+                    $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+                } else {
+                    $model = $model->{$dataType->scope}();
+                }
             }
             $dataTypeContent = call_user_func([$model, 'findOrFail'], $id);
         } else {
@@ -316,7 +331,12 @@ class VoyagerBaseController extends Controller
 
         $model = app($dataType->model_name);
         if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-            $model = $model->{$dataType->scope}();
+            $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+            if (method_exists($this, $scopeParamsMethod)) {
+                $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+            } else {
+                $model = $model->{$dataType->scope}();
+            }
         }
         if ($model && in_array(SoftDeletes::class, class_uses_recursive($model))) {
             $data = $model->withTrashed()->findOrFail($id);
@@ -502,7 +522,12 @@ class VoyagerBaseController extends Controller
         // Get record
         $model = call_user_func([$dataType->model_name, 'withTrashed']);
         if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-            $model = $model->{$dataType->scope}();
+            $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+            if (method_exists($this, $scopeParamsMethod)) {
+                $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+            } else {
+                $model = $model->{$dataType->scope}();
+            }
         }
         $data = $model->findOrFail($id);
 
@@ -864,7 +889,12 @@ class VoyagerBaseController extends Controller
 
                 // Apply local scope if it is defined in the relationship-options
                 if (isset($options->scope) && $options->scope != '' && method_exists($model, 'scope'.ucfirst($options->scope))) {
-                    $model = $model->{$options->scope}();
+                    $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+                    if (method_exists($this, $scopeParamsMethod)) {
+                        $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+                    } else {
+                        $model = $model->{$dataType->scope}();
+                    }
                 }
 
                 // If search query, use LIKE to filter results depending on field label

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -889,11 +889,11 @@ class VoyagerBaseController extends Controller
 
                 // Apply local scope if it is defined in the relationship-options
                 if (isset($options->scope) && $options->scope != '' && method_exists($model, 'scope'.ucfirst($options->scope))) {
-                    $scopeParamsMethod = 'scope'.ucfirst($dataType->scope).'Params';
+                    $scopeParamsMethod = 'scope'.ucfirst($options->scope).'Params';
                     if (method_exists($this, $scopeParamsMethod)) {
-                        $model = call_user_func_array([$model, $dataType->scope], $this->{$scopeParamsMethod}($request));
+                        $model = call_user_func_array([$model, $options->scope], $this->{$scopeParamsMethod}($request));
                     } else {
-                        $model = $model->{$dataType->scope}();
+                        $model = $model->{$options->scope}();
                     }
                 }
 


### PR DESCRIPTION
At the moment the BREAD controllers are only capable of using fixed "scope" filters that take no parameters.

This adds support for dynamic scopes through a straightforward function override convention. e.g.

```php
class Post extends Model {
    public function scopeForCategory($query, $category) {
        return $query->where('category', $category);
    }
}
```
Then in the BREAD setup, the 'forCategory' scope becomes selectable, but will fail on render due to too few parameters. Simple controller override solves this:
```php
class MyPostController extends VoyagerBaseController {
    public function scopeForCategoryParams(Request $request) {
        // grab the category ID dynamically - example is from the request, but could be from anywhere
        return [$request->route()->parameter('category')];
    }
}
```
This pull request is in particular for when you need to grab the parameter dynamically, although it would be also be possible to have a "fixed" parameter passed to a dynamic scope by adding an Optional Details JSON with a `scopeParams` array to the `dataType` configuration itself.