### PR TITLE
Show button back to browse only if allowed to browse

### DIFF
--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -23,11 +23,12 @@
                 </a>
             @endif
         @endcan
-
+        @can('browse', $dataTypeContent)
         <a href="{{ route('voyager.'.$dataType->slug.'.index') }}" class="btn btn-warning">
             <span class="glyphicon glyphicon-list"></span>&nbsp;
             {{ __('voyager::generic.return_to_list') }}
         </a>
+        @endcan
     </h1>
     @include('voyager::multilingual.language-selector')
 @stop


### PR DESCRIPTION
Added check before showing button like the other buttons.
Even if it's unusual to have the ability to view without the ability to browse it can still happen and it make sense to have permission check anyway.