### PR TITLE
Initial Laravel 8 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Install PHP dependencies
       - name: Install legacy factories for Laravel
-        if: matrix.laravel == "8.*"
+        if: ${{ matrix.laravel == "8.*" }}
         run: composer require laravel/legacy-factories
 
       # Display installed laravel version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [7.3, 7.4]
-        laravel: ['6.*', '7.*']
+        laravel: ['6.*', '7.*', '8.*']
 
     name: 'PHP ${{ matrix.php }} / ${{ matrix.laravel }}'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install Composer dependencies
         run: composer require "illuminate/support:${{ matrix.laravel }}"
 
+      # Install PHP dependencies
+      - name: Install legacy factories for Laravel
+        if: matrix.laravel == "8.*"
+        run: composer require laravel/legacy-factories
+
       # Display installed laravel version
       - name: Show laravel version
         run: composer show laravel/framework

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
 
       # Install PHP dependencies
       - name: Install legacy factories for Laravel
-        if: ${{ matrix.laravel == "8.*" }}
+        if: ${{ matrix.laravel == '8.*' }}
         run: composer require laravel/legacy-factories
 
       # Display installed laravel version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Composer dependencies
         run: composer require "illuminate/support:${{ matrix.laravel }}"
 
-      # Install PHP dependencies
+      # Install legacy factories for Laravel 8
       - name: Install legacy factories for Laravel
         if: ${{ matrix.laravel == '8.*' }}
         run: composer require laravel/legacy-factories

--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,8 @@
                 "TCG\\Voyager\\Providers\\VoyagerDummyServiceProvider"
             ]
         }
+    },
+    "suggest": {
+        "laravel/legacy-factories": "Required to run Voyager tests with Laravel 8.x"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
         "laravel/framework": "~6.0|~7.0|~8.0",
         "orchestra/testbench": ">=4.0",
         "laravel/browser-kit-testing": ">=5.0.0",
-        "orchestra/testbench-browser-kit": ">=4.0",
-        "laravel/legacy-factories": "1.0.4"
+        "orchestra/testbench-browser-kit": ">=4.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Laravel Admin Package for The Control Group to make your life easier and steer your project in the right direction",
     "keywords": ["laravel", "admin", "panel"],
     "license": "MIT",
-    "homepage": "https://the-control-group.github.io/voyager/",
+    "homepage": "https://voyager.devdojo.com/",
     "support": {
         "issues": "https://github.com/the-control-group/voyager/issues",
         "source": "https://github.com/the-control-group/voyager"
@@ -15,23 +15,24 @@
         }
     ],
     "require": {
-        "illuminate/support": "~6.0|~7.0",
+        "illuminate/support": "~6.0|~7.0|~8.0",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",
         "larapack/doctrine-support": "~0.1.4",
         "laravel/ui": ">=1.0",
         "arrilot/laravel-widgets": "^3.7",
-        "league/flysystem": "^1.0.41",
+        "league/flysystem": "~1.1|~2.0",
         "larapack/voyager-hooks": "~1.2.1",
         "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpcov": ">=6.0",
         "phpunit/phpunit": ">=8.0",
-        "laravel/framework": "~6.0|~7.0",
+        "laravel/framework": "~6.0|~7.0|~8.0",
         "orchestra/testbench": ">=4.0",
         "laravel/browser-kit-testing": ">=5.0.0",
-        "orchestra/testbench-browser-kit": ">=4.0"
+        "orchestra/testbench-browser-kit": ">=4.0",
+        "laravel/legacy-factories": "1.0.4"
     },
     "autoload": {
         "psr-4": {

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -3,5 +3,6 @@
 Before installing Voyager make sure you have installed one of the following versions of Laravel:
 - Laravel 6
 - Laravel 7
+- Laravel 8
 
 Additionally Voyager requires you to use PHP 7.3 or newer.


### PR DESCRIPTION
This PR adds Laravel 8 support.
Tests **will** fail until Laravel releases a stable version 8.
Tests **pass** when `minimum-stability` is set to `dev` in `composer.json`

Once 8.0.1 is released, re-run actions to verify all tests pass, merge this PR, release a new version and we are good!