### PR TITLE
Fixes for Laravel 8

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -77,13 +77,15 @@ class InstallCommand extends Command
         $this->call('migrate', ['--force' => $this->option('force')]);
 
         $this->info('Attempting to set Voyager User model as parent to App\User');
-        if (file_exists(app_path('User.php'))) {
-            $str = file_get_contents(app_path('User.php'));
+        if (file_exists(app_path('User.php')) || file_exists(app_path('Models/User.php'))) {
+            $userPath = file_exists(app_path('User.php')) ? app_path('User.php') : app_path('Models/User.php');
+
+            $str = file_get_contents($userPath);
 
             if ($str !== false) {
                 $str = str_replace('extends Authenticatable', "extends \TCG\Voyager\Models\User", $str);
 
-                file_put_contents(app_path('User.php'), $str);
+                file_put_contents($userPath, $str);
             }
         } else {
             $this->warn('Unable to locate "app/User.php".  Did you move this file?');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -88,7 +88,7 @@ class InstallCommand extends Command
                 file_put_contents($userPath, $str);
             }
         } else {
-            $this->warn('Unable to locate "app/User.php".  Did you move this file?');
+            $this->warn('Unable to locate "User.php" in app or app/Models.  Did you move this file?');
             $this->warn('You will need to update this manually.  Change "extends Authenticatable" to "extends \TCG\Voyager\Models\User" in your User model');
         }
 

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+use Illuminate\Pagination\Paginator;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Auth;
@@ -131,6 +132,8 @@ class VoyagerServiceProvider extends ServiceProvider
         });
 
         $this->bootTranslatorCollectionMacros();
+
+        Paginator::useBootstrap();
     }
 
     /**

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -133,7 +133,9 @@ class VoyagerServiceProvider extends ServiceProvider
 
         $this->bootTranslatorCollectionMacros();
 
-        Paginator::useBootstrap();
+        if (method_exists('Paginator', 'useBootstrap')) {
+            Paginator::useBootstrap();
+        }
     }
 
     /**


### PR DESCRIPTION
Laravel 8 moved default location of `User` from `App` to `App\Models`.

This PR enables checking both locations before giving up.

Fixed Paginator since Laravel 8 uses Tailwind as default styling.