### PR TITLE
Allow permissions and role restrictions for menu items

### DIFF
--- a/migrations/2020_10_13_155808_add_permissions_column_to_menu_items.php
+++ b/migrations/2020_10_13_155808_add_permissions_column_to_menu_items.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPermissionsColumnToMenuItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->json("permissions")->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('menu_items', function (Blueprint $table) {
+            $table->dropColumn("permissions");
+        });
+    }
+}

--- a/migrations/2020_10_13_155808_add_permissions_column_to_menu_items.php
+++ b/migrations/2020_10_13_155808_add_permissions_column_to_menu_items.php
@@ -14,7 +14,7 @@ class AddPermissionsColumnToMenuItems extends Migration
     public function up()
     {
         Schema::table('menu_items', function (Blueprint $table) {
-            $table->json("permissions")->nullable();
+            $table->json('permissions')->nullable();
         });
     }
 
@@ -26,7 +26,7 @@ class AddPermissionsColumnToMenuItems extends Migration
     public function down()
     {
         Schema::table('menu_items', function (Blueprint $table) {
-            $table->dropColumn("permissions");
+            $table->dropColumn('permissions');
         });
     }
 }

--- a/publishable/lang/en/menu_builder.php
+++ b/publishable/lang/en/menu_builder.php
@@ -14,6 +14,7 @@ return [
     'icon_class_ph'        => 'Icon Class (optional)',
     'item_route'           => 'Route for the menu item',
     'item_title'           => 'Title of the Menu Item',
+    'permissions'          => 'Permissions',
     'link_type'            => 'Link type',
     'new_menu_item'        => 'New Menu Item',
     'open_in'              => 'Open In',

--- a/resources/views/menu/admin.blade.php
+++ b/resources/views/menu/admin.blade.php
@@ -16,6 +16,7 @@
                 data-color="{{ $item->color }}"
                 data-route="{{ $item->route }}"
                 data-parameters="{{ json_encode($item->parameters) }}"
+                data-permissions="{{ $item->permissions }}"
             >
                 <i class="voyager-edit"></i> {{ __('voyager::generic.edit') }}
             </div>

--- a/resources/views/menus/builder.blade.php
+++ b/resources/views/menus/builder.blade.php
@@ -108,6 +108,25 @@
                         </select>
                         <input type="hidden" name="menu_id" value="{{ $menu->id }}">
                         <input type="hidden" name="id" id="m_id" value="">
+
+                        <br>
+                        <label for="permissions">{{ __('voyager::menu_builder.permissions') }}</label>
+                        <div>
+                            <select id="m_permission_name" class="col-6 form-control update-permissions">
+                                <option value="" disabled="disabled" selected="selected">Select Permission</option>
+                                @foreach($permissions as $permission)
+                            <option value="{{$permission->key}}">{{$permission->key}}</option>
+                            @endforeach
+                            </select>
+                            <select id="m_role_name" class="col-6 form-control update-permissions">
+                                <option value="" disabled="disabled" selected="selected">Select Role</option>
+                                @foreach($roles as $role)
+                            <option value="{{$role->name}}">{{$role->display_name}}</option>
+                            @endforeach
+                            </select>
+                            <input  id="m_permissions" name="permissions" type="hidden"><br>
+                        </div>
+
                     </div>
                     <div class="modal-footer">
                         <input type="submit" class="btn btn-success pull-right delete-confirm__" value="{{ __('voyager::generic.update') }}">
@@ -146,6 +165,12 @@
                 });
             @endif
 
+            $(".update-permissions").change((e) => {
+                let new_value = {};
+                if (e.target.id == "m_role_name" && e.target.value!="") {new_value.needs_role = e.target.value; $("#m_permission_name").val("")};
+                if (e.target.id == "m_permission_name" && e.target.value!="") {new_value.needs_permission = e.target.value; $("#m_role_name").val("")};
+                $("#m_permissions").val(JSON.stringify(new_value));
+            })
 
             $('.dd').nestable({
                 expandBtnHTML: '',
@@ -172,7 +197,8 @@
                 $m_icon_class  = $('#m_icon_class'),
                 $m_color       = $('#m_color'),
                 $m_target      = $('#m_target'),
-                $m_id          = $('#m_id');
+                $m_id          = $('#m_id'),
+                $m_permissions = $('#m_permission_name,#m_role_name');
 
             /**
              * Add Menu
@@ -208,6 +234,7 @@
                     $m_link_type.val('url').change();
                     $m_url.val('');
                     $m_icon_class.val('');
+                    $m_permissions.val('');
 
                 } else {
                     $m_form.attr('action', $m_form.data('action-update'));
@@ -222,9 +249,18 @@
                     $m_url.val(_src.data('url'));
                     $m_route.val(_src.data('route'));
                     $m_parameters.val(JSON.stringify(_src.data('parameters')));
+                    $m_permissions.val(JSON.stringify(_src.data('permissions')));
                     $m_icon_class.val(_src.data('icon_class'));
                     $m_color.val(_src.data('color'));
                     $m_id.val(id);
+
+                    let perms = _src.data('permissions');
+                    console.log("src", _src.data());
+                    if (perms) {
+                        console.log("setting perms",perms);
+                        if (perms.needs_permission) $("#m_permission_name").val(perms.needs_permission);
+                        if (perms.needs_role) $("#m_role_name").val(perms.needs_role);
+                    }
 
                     if(translatable){
                         $_str_i18n = $("#title" + id + "_i18n").val();

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -5,6 +5,8 @@ namespace TCG\Voyager\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Models\Role;
+use TCG\Voyager\Models\Permission;
 
 class VoyagerMenuController extends Controller
 {
@@ -15,8 +17,10 @@ class VoyagerMenuController extends Controller
         $this->authorize('edit', $menu);
 
         $isModelTranslatable = is_bread_translatable(Voyager::model('MenuItem'));
+        $permissions = Permission::all();
+        $roles = Role::all();
 
-        return Voyager::view('voyager::menus.builder', compact('menu', 'isModelTranslatable'));
+        return Voyager::view('voyager::menus.builder', compact('menu', 'isModelTranslatable', 'permissions', 'roles'));
     }
 
     public function delete_menu($menu, $id)

--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -5,8 +5,8 @@ namespace TCG\Voyager\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use TCG\Voyager\Facades\Voyager;
-use TCG\Voyager\Models\Role;
 use TCG\Voyager\Models\Permission;
+use TCG\Voyager\Models\Role;
 
 class VoyagerMenuController extends Controller
 {

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -92,7 +92,7 @@ class Menu extends Model
         }
 
         $items = static::checkItemPermissions($items);
-        
+
         if ($type === '_json') {
             return $items;
         }

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -146,7 +146,7 @@ class Menu extends Model
 
         // Filter items by permission
         $items = $items->filter(function ($item) {
-            info("menu: ", $item);
+            info("SM-menu: ", $item);
             return !$item->children->isEmpty() || Auth::user()->can('browse', $item);
         })->filter(function ($item) {
             // Filter out empty menu-items

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -95,6 +95,8 @@ class Menu extends Model
             return $items;
         }
 
+        info("SM-disp-menu", $items);
+
         return new \Illuminate\Support\HtmlString(
             \Illuminate\Support\Facades\View::make($type, ['items' => $items, 'options' => $options])->render()
         );

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -146,6 +146,7 @@ class Menu extends Model
 
         // Filter items by permission
         $items = $items->filter(function ($item) {
+            info("menu: ", $item);
             return !$item->children->isEmpty() || Auth::user()->can('browse', $item);
         })->filter(function ($item) {
             // Filter out empty menu-items

--- a/src/Models/Menu.php
+++ b/src/Models/Menu.php
@@ -73,6 +73,8 @@ class Menu extends Model
 
         $items = $menu->parent_items->sortBy('order');
 
+        info("SM-got-items", $items);
+
         if ($menuName == 'admin' && $type == '_json') {
             $items = static::processItems($items);
         }
@@ -94,8 +96,6 @@ class Menu extends Model
         if ($type === '_json') {
             return $items;
         }
-
-        info("SM-disp-menu", $items);
 
         return new \Illuminate\Support\HtmlString(
             \Illuminate\Support\Facades\View::make($type, ['items' => $items, 'options' => $options])->render()


### PR DESCRIPTION
Menu items can be displayed or hidden based on certain permissions.

For example, if you want to restrict a menu item to only those users who have the role of `admin` or who have permission `edit_notes`