### PR TITLE
feature convert image format

### DIFF
--- a/src/Http/Controllers/ContentTypes/Image.php
+++ b/src/Http/Controllers/ContentTypes/Image.php
@@ -62,9 +62,11 @@ class Image extends BaseType
             if (isset($this->options->thumbnails)) {
                 foreach ($this->options->thumbnails as $thumbnails) {
                     $image_extension = $file->getClientOriginalExtension();
+                    
                     if (isset($thumbnails->convert)) {
                         $image_extension = $thumbnails->convert;
                     }
+                    
                     if (isset($thumbnails->quality)) {
                         $resize_quality = $thumbnails->quality;
                     }

--- a/src/Http/Controllers/ContentTypes/Image.php
+++ b/src/Http/Controllers/ContentTypes/Image.php
@@ -61,6 +61,14 @@ class Image extends BaseType
 
             if (isset($this->options->thumbnails)) {
                 foreach ($this->options->thumbnails as $thumbnails) {
+                    $image_extension = $file->getClientOriginalExtension();
+                    if (isset($thumbnails->convert)) {
+                        $image_extension = $thumbnails->convert;
+                    }
+                    if (isset($thumbnails->quality)) {
+                        $resize_quality = $thumbnails->quality;
+                    }
+
                     if (isset($thumbnails->name) && isset($thumbnails->scale)) {
                         $scale = intval($thumbnails->scale) / 100;
                         $thumb_resize_width = $resize_width;
@@ -85,18 +93,18 @@ class Image extends BaseType
                                         $constraint->upsize();
                                     }
                                 }
-                            )->encode($file->getClientOriginalExtension(), $resize_quality);
+                            )->encode($image_extension, $resize_quality);
                     } elseif (isset($thumbnails->crop->width) && isset($thumbnails->crop->height)) {
                         $crop_width = $thumbnails->crop->width;
                         $crop_height = $thumbnails->crop->height;
                         $image = InterventionImage::make($file)
                             ->orientate()
                             ->fit($crop_width, $crop_height)
-                            ->encode($file->getClientOriginalExtension(), $resize_quality);
+                            ->encode($image_extension, $resize_quality);
                     }
 
                     Storage::disk(config('voyager.storage.disk'))->put(
-                        $path.$filename.'-'.$thumbnails->name.'.'.$file->getClientOriginalExtension(),
+                        $path.$filename.'-'.$thumbnails->name.'.'.$image_extension,
                         (string) $image,
                         'public'
                     );


### PR DESCRIPTION
Add support convert image from one format to another in Image thumbnails.

This provide ability to set format which you want convert to.
As example convert image to webp format.
As example:
"thumbnails": [
{
"convert": "webp",
"name": "webp",
"scale": "100%"
},
{
"convert": "webp",
"name": "webp-low-quality",
"scale": "20%"
}
]