### PR TITLE
Change Request::url to Request::path

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -7,7 +7,7 @@
             @section('breadcrumbs')
             <ol class="breadcrumb hidden-xs">
                 @php
-                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard'), '', Request::url())));
+                $segments = array_filter(explode('/', str_replace(route('voyager.dashboard'), '', Request::path())));
                 $url = route('voyager.dashboard');
                 @endphp
                 @if(count($segments) == 0)


### PR DESCRIPTION
The URL for the site was showing up in the dashboard. Request::path removes the URL

![image](https://user-images.githubusercontent.com/1830494/97657934-2324bb80-1a39-11eb-8bef-56a8df3a7f09.png)
