### PR TITLE
Add support for custom favicons with admin icon as backup

### DIFF
--- a/publishable/database/seeds/SettingsTableSeeder.php
+++ b/publishable/database/seeds/SettingsTableSeeder.php
@@ -65,7 +65,7 @@ class SettingsTableSeeder extends Seeder
                 'value'        => '',
                 'details'      => '',
                 'type'         => 'image',
-                'order'        => 5,
+                'order'        => 6,
                 'group'        => 'Admin',
             ])->save();
         }
@@ -114,6 +114,18 @@ class SettingsTableSeeder extends Seeder
                 'details'      => '',
                 'type'         => 'image',
                 'order'        => 4,
+                'group'        => 'Admin',
+            ])->save();
+        }
+
+        $setting = $this->findSetting('admin.favicon_image');
+        if (!$setting->exists) {
+            $setting->fill([
+                'display_name' => __('voyager::seeders.settings.admin.favicon_image'),
+                'value'        => '',
+                'details'      => '',
+                'type'         => 'image',
+                'order'        => 5,
                 'group'        => 'Admin',
             ])->save();
         }

--- a/publishable/lang/en/seeders.php
+++ b/publishable/lang/en/seeders.php
@@ -78,6 +78,7 @@ return [
             'background_image'           => 'Admin Background Image',
             'description'                => 'Admin Description',
             'description_value'          => 'Welcome to Voyager. The Missing Admin for Laravel',
+            'favicon_image'              => 'Admin Favicon Image',
             'google_analytics_client_id' => 'Google Analytics Client ID (used for admin dashboard)',
             'icon_image'                 => 'Admin Icon Image',
             'loader'                     => 'Admin Loader',

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
 
     <!-- Favicon -->
-    <?php $admin_favicon = Voyager::setting('admin.icon_image', ''); ?>
+    <?php $admin_favicon = Voyager::setting('admin.favicon_image', Voyager::setting('admin.icon_image', '')); ?>
     @if($admin_favicon == '')
         <link rel="shortcut icon" href="{{ voyager_asset('images/logo-icon.png') }}" type="image/png">
     @else


### PR DESCRIPTION
At the moment the default admin icon is white and the default favicon is black, and these are two separate alternatives that share a single Admin Setting.

This PR separates these out so that:
* if the favicon is defined, it uses that for the favicon (but not the admin icon)
* if the favicon is undefined and the admin icon is defined, then it uses the admin icon for the favicon
* if neither admin icon or favicon are defined, the favicon falls back to the existing default