### PR TITLE
Feature server side order and search for belongsto field

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -85,7 +85,7 @@
                                         @endif
                                         @foreach($dataType->browseRows as $row)
                                         <th>
-                                            @if ($isServerSide && $row->type !== 'relationship')
+                                            @if ($isServerSide && ($row->type !== 'relationship' || $row->details->type == 'belongsTo'))
                                                 <a href="{{ $row->sortByUrl($orderBy, $sortOrder) }}">
                                             @endif
                                             {{ $row->getTranslatedAttribute('display_name') }}

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -3,6 +3,7 @@
 namespace TCG\Voyager\Http\Controllers;
 
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -70,11 +71,27 @@ class VoyagerBaseController extends Controller
         if (strlen($dataType->model_name) != 0) {
             $model = app($dataType->model_name);
 
-            if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
-                $query = $model->{$dataType->scope}();
-            } else {
-                $query = $model::select('*');
+            $relationshipRows = $dataType->rows->where('type', 'relationship');
+
+            if ($search->value != '' && $search->key && $search->filter) {
+                $search_filter = ($search->filter == 'equals') ? '=' : 'LIKE';
+                $search_value = ($search->filter == 'equals') ? $search->value : '%'.$search->value.'%';
+
+                $searchField = $dataType->name.'.'.$search->key;
+                if ($row = $this->findRelationshipRow($relationshipRows, $search->key)) {
+                    $dataType->model_name::addGlobalScope('filter', function (Builder $builder) use($row, $searchField, $search_filter, $search_value) {
+                        $builder->whereIn(
+                            $searchField,
+                            $row->details->model::where($row->details->label, $search_filter, $search_value)->pluck('id')->toArray()
+                        );
+                    });
+                } else {
+                    $query = $this->getQuery($dataType, $model);
+                    $query->where($searchField, $search_filter, $search_value);
+                }
             }
+
+            $query = $query ?? $this->getQuery($dataType, $model);
 
             // Use withTrashed() if model uses SoftDeletes and if toggle is selected
             if ($model && in_array(SoftDeletes::class, class_uses_recursive($model)) && Auth::user()->can('delete', app($dataType->model_name))) {
@@ -88,12 +105,6 @@ class VoyagerBaseController extends Controller
 
             // If a column has a relationship associated with it, we do not want to show that field
             $this->removeRelationshipField($dataType, 'browse');
-
-            if ($search->value != '' && $search->key && $search->filter) {
-                $search_filter = ($search->filter == 'equals') ? '=' : 'LIKE';
-                $search_value = ($search->filter == 'equals') ? $search->value : '%'.$search->value.'%';
-                $query->where($model->getTable().'.'.$search->key, $search_filter, $search_value);
-            }
 
             $row = $dataType->rows->where('field', $orderBy)->firstWhere('type', 'relationship');
             if ($orderBy && (in_array($orderBy, $dataType->fields()) || !empty($row))) {
@@ -936,5 +947,23 @@ class VoyagerBaseController extends Controller
 
         // No result found, return empty array
         return response()->json([], 404);
+    }
+
+    protected function getQuery($dataType, $model)
+    {
+        $query = $model::select($dataType->name.'.*');
+
+        if ($dataType->scope && $dataType->scope != '' && method_exists($model, 'scope'.ucfirst($dataType->scope))) {
+            $query->{$dataType->scope}();
+        }
+
+        return $query;
+    }
+
+    protected function findRelationshipRow($relationshipRows, $searchKey)
+    {
+        return $relationshipRows->filter(function ($item) use ($searchKey) {
+            return $item->details->type == 'belongsTo' && $item->details->column == $searchKey;
+        })->first();
     }
 }

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -119,7 +119,7 @@ class VoyagerBaseController extends Controller
                 }
 
                 $dataTypeContent = call_user_func([
-                    $query->orderBy($orderBy ?? $orderBy, $querySortOrder),
+                    $query->orderBy($orderBy, $querySortOrder),
                     $getter,
                 ]);
             } elseif ($model->timestamps) {

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -3,8 +3,14 @@
 namespace TCG\Voyager\Tests;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
+use TCG\Voyager\Http\Controllers\VoyagerBaseController;
+use TCG\Voyager\Models\DataRow;
+use TCG\Voyager\Models\DataType;
 use TCG\Voyager\Models\Post;
+use TCG\Voyager\Models\User;
 
 class SearchTest extends TestCase
 {
@@ -17,6 +23,7 @@ class SearchTest extends TestCase
         parent::setUp();
 
         $this->user = Auth::loginUsingId(1);
+        $this->withFactories(__DIR__.'/database/factories');
     }
 
     public function testCanSearchEquals0()
@@ -37,5 +44,102 @@ class SearchTest extends TestCase
         $this->visit(route('voyager.posts.index').'?'.http_build_query($params))
             ->see($post->title)
             ->dontSee(Post::where('featured', 0)->first()->title);
+    }
+
+    public function testCanSearchByBelongstoRelationship()
+    {
+        $this->setupAuthorRelationship();
+
+        $user = User::all()->first();
+        $post = Post::all()->first();
+        $post->author_id = $user->id;
+        $post->save();
+
+        $params = [
+            'key'    => 'author_id',
+            'filter' => 'contains',
+            's'      => substr($user->name, 0, 2),
+        ];
+
+        $response = $this->fakeVisit('voyager.posts.index', 'GET', $params);
+
+        $this->assertCount(1, $response->dataTypeContent);
+        $this->assertEquals($post->id, $response->dataTypeContent->first()->id);
+
+        $params['s'] = 'random';
+
+        $response = $this->fakeVisit('voyager.posts.index', 'GET', $params);
+
+        $this->assertCount(0, $response->dataTypeContent);
+    }
+
+    public function testCanOrderAndSearchByBelongstoRelationship()
+    {
+        $this->setupAuthorRelationship();
+
+        $posts = Post::all();
+        $user = User::all()->first();
+        $post = $posts->first();
+        $post->author_id = $user->id;
+        $post->save();
+
+        $other_user = factory(User::class)->create(['name' => 'Admin 2']);
+        $other_post = $posts->last();
+        $other_post->author_id = $other_user->id;
+        $other_post->save();
+
+        $params = [
+            'key'    => 'author_id',
+            'filter' => 'contains',
+            's'      => substr($user->name, 0, 2),
+            'sort_order' => 'asc',
+            'order_by' => 'post_belongsto_user_relationship'
+        ];
+
+        $response = $this->fakeVisit('voyager.posts.index', 'GET', $params);
+
+        $this->assertCount(2, $response->dataTypeContent);
+        $this->assertEquals($post->id, $response->dataTypeContent[0]->id);
+        $this->assertEquals($other_post->id, $response->dataTypeContent[1]->id);
+
+        $params['sort_order'] = 'desc';
+
+        $response = $this->fakeVisit('voyager.posts.index', 'GET', $params);
+
+        $this->assertCount(2, $response->dataTypeContent);
+        $this->assertEquals($other_post->id, $response->dataTypeContent[0]->id);
+        $this->assertEquals($post->id, $response->dataTypeContent[1]->id);
+    }
+
+    protected function fakeVisit($route, $method = 'GET', $params = [])
+    {
+        $request = Request::create(route($route), $method, $params);
+        $request->setRouteResolver(function() use ($route) {
+            $stub = $this->getMockBuilder(Route::class)
+                    ->addMethods(['getName'])
+                    ->getMock();
+            $stub->method('getName')->willReturn($route);
+            return $stub;
+        });
+
+        return (new VoyagerBaseController())->index($request);
+    }
+
+    protected function setupAuthorRelationship()
+    {
+        DataRow::create([
+            'data_type_id' => DataType::where('slug', 'posts')->first()->id,
+            'field' => 'post_belongsto_user_relationship',
+            'type' => 'relationship',
+            'display_name' => 'Author',
+            'details' => [
+                'model' => 'TCG\Voyager\Models\User',
+                'table' => 'users',
+                'type' => 'belongsTo',
+                'column' => 'author_id',
+                'key' => 'id',
+                'label' => 'name',
+            ],
+        ]);
     }
 }


### PR DESCRIPTION
Enable order and search server side for belongsto relationship fields.

~For the search I am applying a global scope, that's the only things that will not require to reimplement pagination manually, for that reason I had to move search checks because globalScope needs to be added as first thing or will not work.~

Added a couple of tests, both using a scope and sofdelete work but we should probably add tests for those too.

Closes #2661 and closes #3595

Supersede #5120