### PR TITLE
Add support for custom pagination view

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -257,4 +257,26 @@ return [
            ],
        ]*/
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination specific settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you change pagination view setting
+    |
+    | Currently Laravel support:
+    | - pagination::default (Bootstrap 3)
+    | - pagination::bootstrap-4
+    | - pagination::tailwind (default in Laravel 8.x)
+    |
+    | of course, you can customize pagination view
+    | https://laravel.com/docs/8.x/pagination#customizing-the-pagination-view
+    |
+    */
+
+    'pagination' => [
+        // Pagination view name
+        'view' => 'pagination::default'
+    ]
 ];

--- a/publishable/config/voyager_dummy.php
+++ b/publishable/config/voyager_dummy.php
@@ -244,4 +244,26 @@ return [
            ],
        ]*/
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination specific settings
+    |--------------------------------------------------------------------------
+    |
+    | Here you change pagination view setting
+    |
+    | Currently Laravel support:
+    | - pagination::default (Bootstrap 3)
+    | - pagination::bootstrap-4
+    | - pagination::tailwind (default in Laravel 8.x)
+    |
+    | of course, you can customize pagination view
+    | https://laravel.com/docs/8.x/pagination#customizing-the-pagination-view
+    |
+    */
+
+    'pagination' => [
+        // Pagination view name
+        'view' => 'pagination::default'
+    ]
 ];

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -279,7 +279,7 @@
                                     'order_by' => $orderBy,
                                     'sort_order' => $sortOrder,
                                     'showSoftDeleted' => $showSoftDeleted,
-                                ])->links() }}
+                                ])->links(config('pagination.view')) }}
                             </div>
                         @endif
                     </div>


### PR DESCRIPTION
 ### Add support for custom pagination

By default laravel 8.x uses tailwind for pagination. So the pagination will look like below:

<img width="343" alt="Screen Shot 2021-01-06 at 20 12 10" src="https://user-images.githubusercontent.com/9191807/103762635-fbb32600-505b-11eb-89d0-c2c459d17738.png">
Of course it is possible to use the instructions below to change the view of pagination but it will take away the flexibility of this option. So I added an option to allow users to change the view of pagination.

Refs:
- 8.x uses tailwind: https://laravel.com/docs/8.x/pagination#displaying-pagination-results
- Using Bootstrap: https://laravel.com/docs/8.x/pagination#using-bootstrap