### PR TITLE
Fix hasOne and hasMany setting in BREAD

### DIFF
--- a/resources/views/tools/bread/edit-add.blade.php
+++ b/resources/views/tools/bread/edit-add.blade.php
@@ -558,8 +558,14 @@
 
         /********** Relationship functionality **********/
 
-       $(function () {
+        $(function () {
             $('.relationship_type').change(function(){
+                $(this).parent().parent().find('.belongsToManyShow, .belongsToShow, .hasOneShow, .hasManyShow').hide();
+                $(this).parent().parent().find('.' + $(this).val() + 'Show').show();
+                // hasOneShow has a prepopulated select, only one between the following should be enabled
+                $(this).parent().parent().find('.hasOneShow select').attr('disabled', true);
+                $(this).parent().parent().find('.belongsToShow select').attr('disabled', false);
+
                 if($(this).val() == 'belongsTo'){
                     $(this).parent().parent().find('.relationshipField').show();
                     $(this).parent().parent().find('.relationshipPivot').hide();
@@ -572,12 +578,14 @@
                     $(this).parent().parent().find('.relationship_taggable').hide();
                     $(this).parent().parent().find('.hasOneMany').addClass('flexed');
                     $(this).parent().parent().find('.belongsTo').removeClass('flexed');
+                    $(this).parent().parent().find('.hasOneShow select').attr('disabled', false);
+                    $(this).parent().parent().find('.belongsToShow select').attr('disabled', true);
                 } else {
                     $(this).parent().parent().find('.relationshipField').hide();
                     $(this).parent().parent().find('.relationshipPivot').css('display', 'flex');
                     $(this).parent().parent().find('.relationship_taggable').show();
                 }
-            });
+            }).trigger('change');
 
             $('.btn-new-relationship').click(function(){
                 // Update table data

--- a/resources/views/tools/bread/relationship-new-modal.blade.php
+++ b/resources/views/tools/bread/relationship-new-modal.blade.php
@@ -59,11 +59,19 @@
 				                        <select name="relationship_label" class="rowDrop select2" data-table="{{ $tables[0] }}" data-selected="" style="width: 100%">
 				                        </select>
 				                    </p>
-				                    <p class="relationship_key"><strong>{{ __('voyager::database.relationship.store_the') }} <span class="label_table_name"></span>: </strong>
+									<p class="relationship_key belongsToShow belongsToManyShow"><strong>{{ __('voyager::database.relationship.store_the') }}
+                                        <span class="label_table_name"></span>: </strong>
 				                        <select name="relationship_key" class="rowDrop select2" data-table="{{ $tables[0] }}" data-selected="" style="width: 100%">
 				                        </select>
 									</p>
-
+                                    <p class="relationship_key hasOneShow hasManyShow"><strong>{{ __('voyager::database.relationship.store_the') }}
+                                        <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span>: </strong>
+                                        <select name="relationship_key" class="select2" style="width: 100%">
+                                            @foreach($fieldOptions as $data)
+                                                <option value="{{ $data['field'] }}">{{ $data['field'] }}</option>
+                                            @endforeach
+                                        </select>
+                                    </p>
 									<p class="relationship_taggable"><strong>{{ __('voyager::database.relationship.allow_tagging') }}:</strong> <br>
 										<input type="checkbox" name="relationship_taggable" class="toggleswitch" data-on="{{ __('voyager::generic.yes') }}" data-off="{{ __('voyager::generic.no') }}">
 				                    </p>

--- a/resources/views/tools/bread/relationship-partial.blade.php
+++ b/resources/views/tools/bread/relationship-partial.blade.php
@@ -92,16 +92,28 @@
             <select name="relationship_label_{{ $relationship['field'] }}" class="rowDrop select2" data-table="{{ $relationshipDetails->table ?? '' }}" data-selected="{{ $relationshipDetails->label ?? ''}}">
                 <option value="{{ $relationshipDetails->label ?? '' }}">{{ $relationshipDetails->label ?? '' }}</option>
             </select>
-            <label class="relationship_key" style="@if($relationshipDetails->type == 'belongsTo' || $relationshipDetails->type == 'belongsToMany') display:block @endif">{{ __('voyager::database.relationship.store_the') }} <span class="label_table_name"></span></label>
-            <select name="relationship_key_{{ $relationship['field'] }}" class="rowDrop select2 relationship_key" style="@if($relationshipDetails->type == 'belongsTo' || $relationshipDetails->type == 'belongsToMany') display:block @endif" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="@if(isset($relationshipDetails->key)){{ $relationshipDetails->key }}@endif">
-                <option value="{{ $relationshipDetails->key ?? '' }}">{{ $relationshipDetails->key ?? '' }}</option>
-            </select>
+            <div class="belongsToShow belongsToManyShow relationship_details_content" style="flex:1">
+                <label class="relationship_key">{{ __('voyager::database.relationship.store_the') }} <span class="label_table_name"></span></label>
+                <select name="relationship_key_{{ $relationship['field'] }}" class="rowDrop select2 relationship_key" data-table="@if(isset($relationshipDetails->table)){{ $relationshipDetails->table }}@endif" data-selected="@if(isset($relationshipDetails->key)){{ $relationshipDetails->key }}@endif">
+                    <option value="{{ $relationshipDetails->key ?? '' }}">{{ $relationshipDetails->key ?? '' }}</option>
+                </select>
+            </div>
+            <div class="hasOneShow hasManyShow relationship_details_content" style="flex:1">
+                <label class="relationship_key">{{ __('voyager::database.relationship.store_the') }}
+                    <span>{{ \Illuminate\Support\Str::singular(ucfirst($table)) }}</span>
+                </label>
+                <select name="relationship_key_{{ $relationship['field'] }}" class="select2 relationship_key">
+                    @foreach($fieldOptions as $data)
+                        <option value="{{ $data['field'] }}" @if($relationshipDetails->key == $data['field']) selected="selected" @endif>{{ $data['field'] }}</option>
+                    @endforeach
+                </select>
+            </div>
             <br>
             @isset($relationshipDetails->taggable)
-                <label class="relationship_taggable" style="@if($relationshipDetails->type == 'belongsToMany') display:block @endif">
+                <label class="relationship_taggable">
                     {{__('voyager::database.relationship.allow_tagging')}}
                 </label>
-                <span class="relationship_taggable" style="@if($relationshipDetails->type == 'belongsToMany') display:block @endif">
+                <span class="relationship_taggable">
                     <input type="checkbox" name="relationship_taggable_{{ $relationship['field'] }}" class="toggleswitch" data-on="{{ __('voyager::generic.yes') }}" data-off="{{ __('voyager::generic.no') }}" {{$relationshipDetails->taggable == 'on' ? 'checked' : ''}}>
                 </span>
             @endisset


### PR DESCRIPTION
**Store the** was picking the wrong table for `hasOne` and `hasMany`.
It should be the same table so it can be populated server side.

Removed the check for `display:block` because everything is done with javascript at startup with `trigger('change')`

Fixes #5074 