### PR TITLE
[1.4] [Hotfix] Replace Auth::user() with helper method auth()->user()

### DIFF
--- a/resources/views/dashboard/navbar.blade.php
+++ b/resources/views/dashboard/navbar.blade.php
@@ -41,8 +41,8 @@
                     <li class="profile-img">
                         <img src="{{ $user_avatar }}" class="profile-img">
                         <div class="profile-body">
-                            <h5>{{ Auth::user()->name }}</h5>
-                            <h6>{{ Auth::user()->email }}</h6>
+                            <h5>{{ auth()->user()->name }}</h5>
+                            <h6>{{ auth()->user()->email }}</h6>
                         </div>
                     </li>
                     <li class="divider"></li>

--- a/resources/views/dashboard/sidebar.blade.php
+++ b/resources/views/dashboard/sidebar.blade.php
@@ -19,9 +19,9 @@
                  style="background-image:url({{ Voyager::image( Voyager::setting('admin.bg_image'), voyager_asset('images/bg.jpg') ) }}); background-size: cover; background-position: 0px;">
                 <div class="dimmer"></div>
                 <div class="panel-content">
-                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ Auth::user()->name }} avatar">
-                    <h4>{{ ucwords(Auth::user()->name) }}</h4>
-                    <p>{{ Auth::user()->email }}</p>
+                    <img src="{{ $user_avatar }}" class="avatar" alt="{{ auth()->user()->name }} avatar">
+                    <h4>{{ ucwords(auth()->user()->name) }}</h4>
+                    <p>{{ auth()->user()->email }}</p>
 
                     <a href="{{ route('voyager.profile') }}" class="btn btn-primary">{{ __('voyager::generic.profile') }}</a>
                     <div style="clear:both"></div>

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -64,10 +64,10 @@
 </div>
 
 <?php
-if (\Illuminate\Support\Str::startsWith(Auth::user()->avatar, 'http://') || \Illuminate\Support\Str::startsWith(Auth::user()->avatar, 'https://')) {
-    $user_avatar = Auth::user()->avatar;
+if (\Illuminate\Support\Str::startsWith(auth()->user()->avatar, 'http://') || \Illuminate\Support\Str::startsWith(auth()->user()->avatar, 'https://')) {
+    $user_avatar = auth()->user()->avatar;
 } else {
-    $user_avatar = Voyager::image(Auth::user()->avatar);
+    $user_avatar = Voyager::image(auth()->user()->avatar);
 }
 ?>
 

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -13,13 +13,13 @@
     <div style="background-size:cover; background-image: url({{ Voyager::image( Voyager::setting('admin.bg_image'), voyager_asset('/images/bg.jpg')) }}); background-position: center center;position:absolute; top:0; left:0; width:100%; height:300px;"></div>
     <div style="height:160px; display:block; width:100%"></div>
     <div style="position:relative; z-index:9; text-align:center;">
-        <img src="@if( !filter_var(Auth::user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( Auth::user()->avatar ) }}@else{{ Auth::user()->avatar }}@endif"
+        <img src="@if( !filter_var(auth()->user()->avatar, FILTER_VALIDATE_URL)){{ Voyager::image( auth()->user()->avatar ) }}@else{{ auth()->user()->avatar }}@endif"
              class="avatar"
              style="border-radius:50%; width:150px; height:150px; border:5px solid #fff;"
-             alt="{{ Auth::user()->name }} avatar">
-        <h4>{{ ucwords(Auth::user()->name) }}</h4>
-        <div class="user-email text-muted">{{ ucwords(Auth::user()->email) }}</div>
-        <p>{{ Auth::user()->bio }}</p>
+             alt="{{ auth()->user()->name }} avatar">
+        <h4>{{ ucwords(auth()->user()->name) }}</h4>
+        <div class="user-email text-muted">{{ ucwords(auth()->user()->email) }}</div>
+        <p>{{ auth()->user()->bio }}</p>
         @if ($route != '')
             <a href="{{ $route }}" class="btn btn-primary">{{ __('voyager::profile.edit') }}</a>
         @endif


### PR DESCRIPTION
This PR replaces `Auth::user()` with the helper method` auth()->user()` in the blade templates. Using the facade is problamatic since if you are not including the full path to facade, resulting in the error: `Class 'Auth' not found (You have a missing class import. Try importing this class: Illuminate\Support\Facades\Auth.)`.

Tested on Laravel 8 and voyager 1.4.2.