### PR TITLE
Feature cache datatypes

### DIFF
--- a/routes/voyager.php
+++ b/routes/voyager.php
@@ -36,7 +36,7 @@ Route::group(['as' => 'voyager.'], function () {
         Route::get('profile', ['uses' => $namespacePrefix.'VoyagerUserController@profile', 'as' => 'profile']);
 
         try {
-            foreach (Voyager::model('DataType')::all() as $dataType) {
+            foreach (Voyager::model('DataType')::getCached() as $dataType) {
                 $breadController = $dataType->controller
                                  ? Str::start($dataType->controller, '\\')
                                  : $namespacePrefix.'VoyagerBaseController';

--- a/src/Models/DataType.php
+++ b/src/Models/DataType.php
@@ -7,10 +7,12 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use TCG\Voyager\Database\Schema\SchemaManager;
 use TCG\Voyager\Facades\Voyager;
+use TCG\Voyager\Traits\HasCache;
 use TCG\Voyager\Traits\Translatable;
 
 class DataType extends Model
 {
+    use HasCache;
     use Translatable;
 
     protected $translatable = ['display_name_singular', 'display_name_plural'];

--- a/src/Policies/MenuItemPolicy.php
+++ b/src/Policies/MenuItemPolicy.php
@@ -26,7 +26,7 @@ class MenuItemPolicy extends BasePolicy
         }
 
         if (self::$datatypes == null) {
-            self::$datatypes = Voyager::model('DataType')::all()->keyBy('slug');
+            self::$datatypes = Voyager::model('DataType')::getCached()->keyBy('slug');
         }
 
         $regex = str_replace('/', '\/', preg_quote(route('voyager.dashboard')));

--- a/src/Traits/HasCache.php
+++ b/src/Traits/HasCache.php
@@ -1,0 +1,39 @@
+<?php 
+
+namespace TCG\Voyager\Traits;
+
+use Illuminate\Contracts\Cache\Repository as Cache;
+
+trait HasCache
+{
+    protected static $cache_repository = 1;
+    protected static $events_that_clear_cache = ['created', 'deleted', 'saved', 'updated'];
+
+    public static function BootHasCache()
+    {
+        self::$cache_repository = app(Cache::class);
+
+        foreach (self::$events_that_clear_cache as $event) {
+            static::$event(function () {
+                self::clearCache();
+            });
+        }
+    }
+
+    public static function getCached()
+    {
+        return self::$cache_repository->rememberForever(self::getCacheKey(), function () {
+            return static::all();
+        });
+    }
+
+    public static function clearCache()
+    {
+        self::$cache_repository->forget(self::getCacheKey());
+    }
+
+    protected static function getCacheKey($key = null)
+    {
+        return 'has_cache_'.get_class().(!is_null($key) ? '_'.$key : '');
+    }
+}

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -286,7 +286,7 @@ class VoyagerServiceProvider extends ServiceProvider
         try {
             if (Schema::hasTable(VoyagerFacade::model('DataType')->getTable())) {
                 $dataType = VoyagerFacade::model('DataType');
-                $dataTypes = $dataType->select('policy_name', 'model_name')->get();
+                $dataTypes = $dataType->getCached();
 
                 foreach ($dataTypes as $dataType) {
                     $policyClass = BasePolicy::class;

--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -284,22 +284,20 @@ class VoyagerServiceProvider extends ServiceProvider
         // otherwise it will throw an error because no database
         // connection has been made yet.
         try {
-            if (Schema::hasTable(VoyagerFacade::model('DataType')->getTable())) {
-                $dataType = VoyagerFacade::model('DataType');
-                $dataTypes = $dataType->getCached();
+            $dataType = VoyagerFacade::model('DataType');
+            $dataTypes = $dataType->getCached();
 
-                foreach ($dataTypes as $dataType) {
-                    $policyClass = BasePolicy::class;
-                    if (isset($dataType->policy_name) && $dataType->policy_name !== ''
-                        && class_exists($dataType->policy_name)) {
-                        $policyClass = $dataType->policy_name;
-                    }
-
-                    $this->policies[$dataType->model_name] = $policyClass;
+            foreach ($dataTypes as $dataType) {
+                $policyClass = BasePolicy::class;
+                if (isset($dataType->policy_name) && $dataType->policy_name !== ''
+                    && class_exists($dataType->policy_name)) {
+                    $policyClass = $dataType->policy_name;
                 }
 
-                $this->registerPolicies();
+                $this->policies[$dataType->model_name] = $policyClass;
             }
+
+            $this->registerPolicies();
         } catch (\PDOException $e) {
             Log::error('No Database connection yet in VoyagerServiceProvider loadAuth()');
         }


### PR DESCRIPTION
Add a Trait to cache data_types with a new method `getCached` used for both routes and policies.
Remove `Schema::hasTable` check because we are already in a try and catch.

Closes #3396

P.S.
Cache key can be customized, but maybe we should add connection name as default to avoid problems in multi-tenant applications.