### PR TITLE
Update custom-realtionship-attributes.md

### DIFF
--- a/docs/customization/custom-realtionship-attributes.md
+++ b/docs/customization/custom-realtionship-attributes.md
@@ -19,3 +19,6 @@ public $additional_attributes = ['full_name'];
 
 Thats it! You can now select `full_name` in your Relationship.
 
+{% hint style="info" %}
+The default `User` model BREAD by default is namespaced as `\TCG\Voyager\Models\User`. Hence, if you are creating custom relationship attribute for your `User`, ensure to change this default namespace to your `User` model's namespace, so as to be able to declare custom attribute on your `User` model
+{% endhint %}


### PR DESCRIPTION
Default Voyager installation comes with User bread already setup, with the namespace already set as \TCG\Voyager\Models\User. Hence, the default installation on Voyager prevents setting of custom relationship attributes on user-defined User model.
This edit includes an information message that saves developer the time wasted poking around to see why attributes defined in the custom model is not usable, irrespective of the model namespace defined when defining the relationship