### PR TITLE
Fix voyager-assets with empty path

### DIFF
--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -82,27 +82,29 @@ class VoyagerController extends Controller
 
     public function assets(Request $request)
     {
-        try {
-            $path = dirname(__DIR__, 3).'/publishable/assets/'.Util::normalizeRelativePath(urldecode($request->path));
-        } catch (\LogicException $e) {
-            abort(404);
-        }
-
-        if (File::exists($path)) {
-            $mime = '';
-            if (Str::endsWith($path, '.js')) {
-                $mime = 'text/javascript';
-            } elseif (Str::endsWith($path, '.css')) {
-                $mime = 'text/css';
-            } else {
-                $mime = File::mimeType($path);
+        if ($request->path) {
+            try {
+                $path = dirname(__DIR__, 3) . '/publishable/assets/' . Util::normalizeRelativePath(urldecode($request->path));
+            } catch (\LogicException $e) {
+                abort(404);
             }
-            $response = response(File::get($path), 200, ['Content-Type' => $mime]);
-            $response->setSharedMaxAge(31536000);
-            $response->setMaxAge(31536000);
-            $response->setExpires(new \DateTime('+1 year'));
 
-            return $response;
+            if (File::exists($path)) {
+                $mime = '';
+                if (Str::endsWith($path, '.js')) {
+                    $mime = 'text/javascript';
+                } elseif (Str::endsWith($path, '.css')) {
+                    $mime = 'text/css';
+                } else {
+                    $mime = File::mimeType($path);
+                }
+                $response = response(File::get($path), 200, ['Content-Type' => $mime]);
+                $response->setSharedMaxAge(31536000);
+                $response->setMaxAge(31536000);
+                $response->setExpires(new \DateTime('+1 year'));
+
+                return $response;
+            }
         }
 
         return response('', 404);


### PR DESCRIPTION
If path is empty (`voyager-assets?path=`) then `File::exists` return true for the directory and caused 500 error trying to serve directory as a file.