### PR TITLE
keep api with clean, keep voyager querys only to web route

### DIFF
--- a/src/VoyagerServiceProvider.php
+++ b/src/VoyagerServiceProvider.php
@@ -32,339 +32,344 @@ use TCG\Voyager\Providers\VoyagerEventServiceProvider;
 use TCG\Voyager\Seed;
 use TCG\Voyager\Translator\Collection as TranslatorCollection;
 
-class VoyagerServiceProvider extends ServiceProvider
-{
-    /**
-     * The policy mappings for the application.
-     *
-     * @var array
-     */
-    protected $policies = [
-        Setting::class  => SettingPolicy::class,
-        MenuItem::class => MenuItemPolicy::class,
-    ];
+$page = explode('/', substr(request()->path(), 0), 2);
+if(str_replace("-"," ", $page[0]) != 'api'){
+	class VoyagerServiceProvider extends ServiceProvider
+	{
+		/**
+		 * The policy mappings for the application.
+		 *
+		 * @var array
+		 */
+		protected $policies = [
+			Setting::class  => SettingPolicy::class,
+			MenuItem::class => MenuItemPolicy::class,
+		];
 
-    protected $gates = [
-        'browse_admin',
-        'browse_bread',
-        'browse_database',
-        'browse_media',
-        'browse_compass',
-        'browse_hooks',
-    ];
+		protected $gates = [
+			'browse_admin',
+			'browse_bread',
+			'browse_database',
+			'browse_media',
+			'browse_compass',
+			'browse_hooks',
+		];
 
-    /**
-     * Register the application services.
-     */
-    public function register()
-    {
-        $this->app->register(VoyagerEventServiceProvider::class);
-        $this->app->register(ImageServiceProvider::class);
-        $this->app->register(VoyagerDummyServiceProvider::class);
-        $this->app->register(VoyagerHooksServiceProvider::class);
-        $this->app->register(DoctrineSupportServiceProvider::class);
+		/**
+		 * Register the application services.
+		 */
+		public function register()
+		{
+			$this->app->register(VoyagerEventServiceProvider::class);
+			$this->app->register(ImageServiceProvider::class);
+			$this->app->register(VoyagerDummyServiceProvider::class);
+			$this->app->register(VoyagerHooksServiceProvider::class);
+			$this->app->register(DoctrineSupportServiceProvider::class);
 
-        $loader = AliasLoader::getInstance();
-        $loader->alias('Voyager', VoyagerFacade::class);
+			$loader = AliasLoader::getInstance();
+			$loader->alias('Voyager', VoyagerFacade::class);
 
-        $this->app->singleton('voyager', function () {
-            return new Voyager();
-        });
+			$this->app->singleton('voyager', function () {
+				return new Voyager();
+			});
 
-        $this->app->singleton('VoyagerGuard', function () {
-            return config('auth.defaults.guard', 'web');
-        });
+			$this->app->singleton('VoyagerGuard', function () {
+				return config('auth.defaults.guard', 'web');
+			});
 
-        $this->loadHelpers();
+			$this->loadHelpers();
 
-        $this->registerAlertComponents();
-        $this->registerFormFields();
+			$this->registerAlertComponents();
+			$this->registerFormFields();
 
-        $this->registerConfigs();
+			$this->registerConfigs();
 
-        if ($this->app->runningInConsole()) {
-            $this->registerPublishableResources();
-            $this->registerConsoleCommands();
-        }
+			if ($this->app->runningInConsole()) {
+				$this->registerPublishableResources();
+				$this->registerConsoleCommands();
+			}
 
-        if (!$this->app->runningInConsole() || config('app.env') == 'testing') {
-            $this->registerAppCommands();
-        }
-    }
+			if (!$this->app->runningInConsole() || config('app.env') == 'testing') {
+				$this->registerAppCommands();
+			}
+		}
 
-    /**
-     * Bootstrap the application services.
-     *
-     * @param \Illuminate\Routing\Router $router
-     */
-    public function boot(Router $router, Dispatcher $event)
-    {
-        if (config('voyager.user.add_default_role_on_register')) {
-            $model = Auth::guard(app('VoyagerGuard'))->getProvider()->getModel();
-            call_user_func($model.'::created', function ($user) use ($model) {
-                if (is_null($user->role_id)) {
-                    call_user_func($model.'::findOrFail', $user->id)
-                        ->setRole(config('voyager.user.default_role'))
-                        ->save();
-                }
-            });
-        }
+		/**
+		 * Bootstrap the application services.
+		 *
+		 * @param \Illuminate\Routing\Router $router
+		 */
+		public function boot(Router $router, Dispatcher $event)
+		{
+			if (config('voyager.user.add_default_role_on_register')) {
+				$model = Auth::guard(app('VoyagerGuard'))->getProvider()->getModel();
+				call_user_func($model.'::created', function ($user) use ($model) {
+					if (is_null($user->role_id)) {
+						call_user_func($model.'::findOrFail', $user->id)
+							->setRole(config('voyager.user.default_role'))
+							->save();
+					}
+				});
+			}
 
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'voyager');
+			$this->loadViewsFrom(__DIR__.'/../resources/views', 'voyager');
 
-        $router->aliasMiddleware('admin.user', VoyagerAdminMiddleware::class);
+			$router->aliasMiddleware('admin.user', VoyagerAdminMiddleware::class);
 
-        $this->loadTranslationsFrom(realpath(__DIR__.'/../publishable/lang'), 'voyager');
+			$this->loadTranslationsFrom(realpath(__DIR__.'/../publishable/lang'), 'voyager');
 
-        if (config('voyager.database.autoload_migrations', true)) {
-            if (config('app.env') == 'testing') {
-                $this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
-            }
+			if (config('voyager.database.autoload_migrations', true)) {
+				if (config('app.env') == 'testing') {
+					$this->loadMigrationsFrom(realpath(__DIR__.'/migrations'));
+				}
 
-            $this->loadMigrationsFrom(realpath(__DIR__.'/../migrations'));
-        }
+				$this->loadMigrationsFrom(realpath(__DIR__.'/../migrations'));
+			}
 
-        $this->loadAuth();
+			$this->loadAuth();
 
-        $this->registerViewComposers();
+			$this->registerViewComposers();
 
-        $event->listen('voyager.alerts.collecting', function () {
-            $this->addStorageSymlinkAlert();
-        });
+			$event->listen('voyager.alerts.collecting', function () {
+				$this->addStorageSymlinkAlert();
+			});
 
-        $this->bootTranslatorCollectionMacros();
+			$this->bootTranslatorCollectionMacros();
 
-        if (method_exists('Paginator', 'useBootstrap')) {
-            Paginator::useBootstrap();
-        }
-    }
+			if (method_exists('Paginator', 'useBootstrap')) {
+				Paginator::useBootstrap();
+			}
+		}
 
-    /**
-     * Load helpers.
-     */
-    protected function loadHelpers()
-    {
-        foreach (glob(__DIR__.'/Helpers/*.php') as $filename) {
-            require_once $filename;
-        }
-    }
+		/**
+		 * Load helpers.
+		 */
+		protected function loadHelpers()
+		{
+			foreach (glob(__DIR__.'/Helpers/*.php') as $filename) {
+				require_once $filename;
+			}
+		}
 
-    /**
-     * Register view composers.
-     */
-    protected function registerViewComposers()
-    {
-        // Register alerts
-        View::composer('voyager::*', function ($view) {
-            $view->with('alerts', VoyagerFacade::alerts());
-        });
-    }
+		/**
+		 * Register view composers.
+		 */
+		protected function registerViewComposers()
+		{
+			// Register alerts
+			View::composer('voyager::*', function ($view) {
+				$view->with('alerts', VoyagerFacade::alerts());
+			});
+		}
 
-    /**
-     * Add storage symlink alert.
-     */
-    protected function addStorageSymlinkAlert()
-    {
-        if (app('router')->current() !== null) {
-            $currentRouteAction = app('router')->current()->getAction();
-        } else {
-            $currentRouteAction = null;
-        }
-        $routeName = is_array($currentRouteAction) ? Arr::get($currentRouteAction, 'as') : null;
+		/**
+		 * Add storage symlink alert.
+		 */
+		protected function addStorageSymlinkAlert()
+		{
+			if (app('router')->current() !== null) {
+				$currentRouteAction = app('router')->current()->getAction();
+			} else {
+				$currentRouteAction = null;
+			}
+			$routeName = is_array($currentRouteAction) ? Arr::get($currentRouteAction, 'as') : null;
 
-        if ($routeName != 'voyager.dashboard') {
-            return;
-        }
+			if ($routeName != 'voyager.dashboard') {
+				return;
+			}
 
-        $storage_disk = (!empty(config('voyager.storage.disk'))) ? config('voyager.storage.disk') : 'public';
+			$storage_disk = (!empty(config('voyager.storage.disk'))) ? config('voyager.storage.disk') : 'public';
 
-        if (request()->has('fix-missing-storage-symlink')) {
-            if (file_exists(public_path('storage'))) {
-                if (@readlink(public_path('storage')) == public_path('storage')) {
-                    rename(public_path('storage'), 'storage_old');
-                }
-            }
+			if (request()->has('fix-missing-storage-symlink')) {
+				if (file_exists(public_path('storage'))) {
+					if (@readlink(public_path('storage')) == public_path('storage')) {
+						rename(public_path('storage'), 'storage_old');
+					}
+				}
 
-            if (!file_exists(public_path('storage'))) {
-                $this->fixMissingStorageSymlink();
-            }
-        } elseif ($storage_disk == 'public') {
-            if (!file_exists(public_path('storage')) || @readlink(public_path('storage')) == public_path('storage')) {
-                $alert = (new Alert('missing-storage-symlink', 'warning'))
-                    ->title(__('voyager::error.symlink_missing_title'))
-                    ->text(__('voyager::error.symlink_missing_text'))
-                    ->button(__('voyager::error.symlink_missing_button'), '?fix-missing-storage-symlink=1');
-                VoyagerFacade::addAlert($alert);
-            }
-        }
-    }
+				if (!file_exists(public_path('storage'))) {
+					$this->fixMissingStorageSymlink();
+				}
+			} elseif ($storage_disk == 'public') {
+				if (!file_exists(public_path('storage')) || @readlink(public_path('storage')) == public_path('storage')) {
+					$alert = (new Alert('missing-storage-symlink', 'warning'))
+						->title(__('voyager::error.symlink_missing_title'))
+						->text(__('voyager::error.symlink_missing_text'))
+						->button(__('voyager::error.symlink_missing_button'), '?fix-missing-storage-symlink=1');
+					VoyagerFacade::addAlert($alert);
+				}
+			}
+		}
 
-    protected function fixMissingStorageSymlink()
-    {
-        app('files')->link(storage_path('app/public'), public_path('storage'));
+		protected function fixMissingStorageSymlink()
+		{
+			app('files')->link(storage_path('app/public'), public_path('storage'));
 
-        if (file_exists(public_path('storage'))) {
-            $alert = (new Alert('fixed-missing-storage-symlink', 'success'))
-                ->title(__('voyager::error.symlink_created_title'))
-                ->text(__('voyager::error.symlink_created_text'));
-        } else {
-            $alert = (new Alert('failed-fixing-missing-storage-symlink', 'danger'))
-                ->title(__('voyager::error.symlink_failed_title'))
-                ->text(__('voyager::error.symlink_failed_text'));
-        }
+			if (file_exists(public_path('storage'))) {
+				$alert = (new Alert('fixed-missing-storage-symlink', 'success'))
+					->title(__('voyager::error.symlink_created_title'))
+					->text(__('voyager::error.symlink_created_text'));
+			} else {
+				$alert = (new Alert('failed-fixing-missing-storage-symlink', 'danger'))
+					->title(__('voyager::error.symlink_failed_title'))
+					->text(__('voyager::error.symlink_failed_text'));
+			}
 
-        VoyagerFacade::addAlert($alert);
-    }
+			VoyagerFacade::addAlert($alert);
+		}
 
-    /**
-     * Register alert components.
-     */
-    protected function registerAlertComponents()
-    {
-        $components = ['title', 'text', 'button'];
+		/**
+		 * Register alert components.
+		 */
+		protected function registerAlertComponents()
+		{
+			$components = ['title', 'text', 'button'];
 
-        foreach ($components as $component) {
-            $class = 'TCG\\Voyager\\Alert\\Components\\'.ucfirst(Str::camel($component)).'Component';
+			foreach ($components as $component) {
+				$class = 'TCG\\Voyager\\Alert\\Components\\'.ucfirst(Str::camel($component)).'Component';
 
-            $this->app->bind("voyager.alert.components.{$component}", $class);
-        }
-    }
+				$this->app->bind("voyager.alert.components.{$component}", $class);
+			}
+		}
 
-    protected function bootTranslatorCollectionMacros()
-    {
-        Collection::macro('translate', function () {
-            $transtors = [];
+		protected function bootTranslatorCollectionMacros()
+		{
+			Collection::macro('translate', function () {
+				$transtors = [];
 
-            foreach ($this->all() as $item) {
-                $transtors[] = call_user_func_array([$item, 'translate'], func_get_args());
-            }
+				foreach ($this->all() as $item) {
+					$transtors[] = call_user_func_array([$item, 'translate'], func_get_args());
+				}
 
-            return new TranslatorCollection($transtors);
-        });
-    }
+				return new TranslatorCollection($transtors);
+			});
+		}
 
-    /**
-     * Register the publishable files.
-     */
-    private function registerPublishableResources()
-    {
-        $publishablePath = dirname(__DIR__).'/publishable';
+		/**
+		 * Register the publishable files.
+		 */
+		private function registerPublishableResources()
+		{
+			$publishablePath = dirname(__DIR__).'/publishable';
 
-        $publishable = [
-            'voyager_avatar' => [
-                "{$publishablePath}/dummy_content/users/" => storage_path('app/public/users'),
-            ],
-            'seeds' => [
-                "{$publishablePath}/database/seeds/" => database_path(Seed::getFolderName()),
-            ],
-            'config' => [
-                "{$publishablePath}/config/voyager.php" => config_path('voyager.php'),
-            ],
+			$publishable = [
+				'voyager_avatar' => [
+					"{$publishablePath}/dummy_content/users/" => storage_path('app/public/users'),
+				],
+				'seeds' => [
+					"{$publishablePath}/database/seeds/" => database_path(Seed::getFolderName()),
+				],
+				'config' => [
+					"{$publishablePath}/config/voyager.php" => config_path('voyager.php'),
+				],
 
-        ];
+			];
 
-        foreach ($publishable as $group => $paths) {
-            $this->publishes($paths, $group);
-        }
-    }
+			foreach ($publishable as $group => $paths) {
+				$this->publishes($paths, $group);
+			}
+		}
 
-    public function registerConfigs()
-    {
-        $this->mergeConfigFrom(
-            dirname(__DIR__).'/publishable/config/voyager.php',
-            'voyager'
-        );
-    }
+		public function registerConfigs()
+		{
+			$this->mergeConfigFrom(
+				dirname(__DIR__).'/publishable/config/voyager.php',
+				'voyager'
+			);
+		}
 
-    public function loadAuth()
-    {
-        // DataType Policies
+		public function loadAuth()
+		{
+			// DataType Policies
 
-        // This try catch is necessary for the Package Auto-discovery
-        // otherwise it will throw an error because no database
-        // connection has been made yet.
-        try {
-            if (Schema::hasTable(VoyagerFacade::model('DataType')->getTable())) {
-                $dataType = VoyagerFacade::model('DataType');
-                $dataTypes = $dataType->select('policy_name', 'model_name')->get();
+			// This try catch is necessary for the Package Auto-discovery
+			// otherwise it will throw an error because no database
+			// connection has been made yet.
+			try {
+				if (Schema::hasTable(VoyagerFacade::model('DataType')->getTable())) {
+					$dataType = VoyagerFacade::model('DataType');
+					$dataTypes = $dataType->select('policy_name', 'model_name')->get();
 
-                foreach ($dataTypes as $dataType) {
-                    $policyClass = BasePolicy::class;
-                    if (isset($dataType->policy_name) && $dataType->policy_name !== ''
-                        && class_exists($dataType->policy_name)) {
-                        $policyClass = $dataType->policy_name;
-                    }
+					foreach ($dataTypes as $dataType) {
+						$policyClass = BasePolicy::class;
+						if (isset($dataType->policy_name) && $dataType->policy_name !== ''
+							&& class_exists($dataType->policy_name)) {
+							$policyClass = $dataType->policy_name;
+						}
 
-                    $this->policies[$dataType->model_name] = $policyClass;
-                }
+						$this->policies[$dataType->model_name] = $policyClass;
+					}
 
-                $this->registerPolicies();
-            }
-        } catch (\PDOException $e) {
-            Log::error('No Database connection yet in VoyagerServiceProvider loadAuth()');
-        }
+					$this->registerPolicies();
+				}
+			} catch (\PDOException $e) {
+				Log::error('No Database connection yet in VoyagerServiceProvider loadAuth()');
+			}
 
-        // Gates
-        foreach ($this->gates as $gate) {
-            Gate::define($gate, function ($user) use ($gate) {
-                return $user->hasPermission($gate);
-            });
-        }
-    }
+			// Gates
+			foreach ($this->gates as $gate) {
+				Gate::define($gate, function ($user) use ($gate) {
+					return $user->hasPermission($gate);
+				});
+			}
+		}
 
-    protected function registerFormFields()
-    {
-        $formFields = [
-            'checkbox',
-            'multiple_checkbox',
-            'color',
-            'date',
-            'file',
-            'image',
-            'multiple_images',
-            'media_picker',
-            'number',
-            'password',
-            'radio_btn',
-            'rich_text_box',
-            'code_editor',
-            'markdown_editor',
-            'select_dropdown',
-            'select_multiple',
-            'text',
-            'text_area',
-            'time',
-            'timestamp',
-            'hidden',
-            'coordinates',
-        ];
+		protected function registerFormFields()
+		{
+			$formFields = [
+				'checkbox',
+				'multiple_checkbox',
+				'color',
+				'date',
+				'file',
+				'image',
+				'multiple_images',
+				'media_picker',
+				'number',
+				'password',
+				'radio_btn',
+				'rich_text_box',
+				'code_editor',
+				'markdown_editor',
+				'select_dropdown',
+				'select_multiple',
+				'text',
+				'text_area',
+				'time',
+				'timestamp',
+				'hidden',
+				'coordinates',
+			];
 
-        foreach ($formFields as $formField) {
-            $class = Str::studly("{$formField}_handler");
+			foreach ($formFields as $formField) {
+				$class = Str::studly("{$formField}_handler");
 
-            VoyagerFacade::addFormField("TCG\\Voyager\\FormFields\\{$class}");
-        }
+				VoyagerFacade::addFormField("TCG\\Voyager\\FormFields\\{$class}");
+			}
 
-        VoyagerFacade::addAfterFormField(DescriptionHandler::class);
+			VoyagerFacade::addAfterFormField(DescriptionHandler::class);
 
-        event(new FormFieldsRegistered($formFields));
-    }
+			event(new FormFieldsRegistered($formFields));
+		}
 
-    /**
-     * Register the commands accessible from the Console.
-     */
-    private function registerConsoleCommands()
-    {
-        $this->commands(Commands\InstallCommand::class);
-        $this->commands(Commands\ControllersCommand::class);
-        $this->commands(Commands\AdminCommand::class);
-    }
+		/**
+		 * Register the commands accessible from the Console.
+		 */
+		private function registerConsoleCommands()
+		{
+			$this->commands(Commands\InstallCommand::class);
+			$this->commands(Commands\ControllersCommand::class);
+			$this->commands(Commands\AdminCommand::class);
+		}
 
-    /**
-     * Register the commands accessible from the App.
-     */
-    private function registerAppCommands()
-    {
-        $this->commands(Commands\MakeModelCommand::class);
-    }
+		/**
+		 * Register the commands accessible from the App.
+		 */
+		private function registerAppCommands()
+		{
+			$this->commands(Commands\MakeModelCommand::class);
+		}
+	}
+} else {
+	class VoyagerServiceProvider extends ServiceProvider {}
 }


### PR DESCRIPTION
Hi guys, this is just a small fix that i hope can help.
In api calls, we lose at least 200 to 700ms with voyager calls, so i made a check to verify if the request is from api or not, if so, then it hides the voyager provider, else, keep everything as it was.
check this print to illustrate:
![Voyager](https://user-images.githubusercontent.com/55155534/112002039-43473b00-8afe-11eb-9663-1fbfcc905ae1.png)

if this is not helpfull , i hope we can find a better way.
