### PR TITLE
Update menu controller to extend base controller for bread

### DIFF
--- a/src/Http/Controllers/VoyagerMenuController.php
+++ b/src/Http/Controllers/VoyagerMenuController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use TCG\Voyager\Facades\Voyager;
 
-class VoyagerMenuController extends Controller
+class VoyagerMenuController extends VoyagerBaseController
 {
     public function builder($id)
     {


### PR DESCRIPTION
Menu is bread and should extend the base controller. This only become an issue if you extend menu controller you get missing index function. 

`class CustomMenuController extends \TCG\Voyager\Http\Controllers\VoyagerMenuController`