### PR TITLE
Require PHP 7.3, 7.4 or 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": "^7.3|^7.4|^8.0",
         "illuminate/support": "~6.0|~7.0|~8.0",
         "intervention/image": "^2.4",
         "doctrine/dbal": "^2.5",


### PR DESCRIPTION
PHP 7.2 (which is EOL) still works with Laravel 6 (which is LTS) but does not work with Voyager.