### PR TITLE
Fix error syntax error, unexpected ')'

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -109,7 +109,7 @@ class VoyagerBaseController extends Controller
                     ])->leftJoin(
                         $row->details->table.' as joined',
                         $dataType->name.'.'.$row->details->column,
-                        'joined.'.$row->details->key,
+                        'joined.'.$row->details->key
                     );
                 }
 


### PR DESCRIPTION
Some of the computers in our company were getting errors because of the comma on the end of line 112 giving syntax error, unexpected ')'.
This fixed it for our PCs, maybe it's just windows PHP that gets this error.