### PR TITLE
Update widgets quantity per line

### DIFF
--- a/src/Voyager.php
+++ b/src/Voyager.php
@@ -203,7 +203,7 @@ class Voyager
 
                 // Every third dimmer, we consider out WidgetGroup filled.
                 // We switch that out with another WidgetGroup.
-                if ($dimmerCount % 3 === 0 && $dimmerCount !== 0) {
+                if ($dimmerCount % config('voyager.dashboard.widgets_per_line') === 0 && $dimmerCount !== 0) {
                     $dimmerGroups[] = $dimmers;
                     $dimmerGroupTag = ceil($dimmerCount / 3);
                     $dimmers = Widget::group("voyager::dimmers-{$dimmerGroupTag}");


### PR DESCRIPTION
The user can define the number of widgets available on the dashboard based on the information provided by the configuration file.
In place of 3 (default), the user can set 4, for example, without needing to edit the dimmers.blade file