### PR TITLE
Change method where to override Voyager models

### DIFF
--- a/docs/customization/overriding-files.md
+++ b/docs/customization/overriding-files.md
@@ -90,7 +90,7 @@ use TCG\Voyager\Facades\Voyager;
 
 class AppServiceProvider extends ServiceProvider
 {
-    public function register()
+    public function boot()
     {
         Voyager::useModel('DataRow', \App\DataRow::class);
     }


### PR DESCRIPTION
If `Voyager::useModel` is used in `register` method `boot` events do not work in the Model.

See related issue for more details.

Closes #5389