### PR TITLE
Fixed URL that pointed to unrelated site

### DIFF
--- a/resources/views/compass/index.blade.php
+++ b/resources/views/compass/index.blade.php
@@ -42,12 +42,12 @@
                     <div class="collapse-content collapse in" id="links">
                         <div class="row">
                             <div class="col-md-4">
-                                <a href="https://docs.laravelvoyager.com" target="_blank" class="voyager-link" style="background-image:url('{{ voyager_asset('images/compass/documentation.jpg') }}')">
+                                <a href="https://voyager-docs.devdojo.com/" target="_blank" class="voyager-link" style="background-image:url('{{ voyager_asset('images/compass/documentation.jpg') }}')">
                                     <span class="resource_label"><i class="voyager-documentation"></i> <span class="copy">{{ __('voyager::compass.links.documentation') }}</span></span>
                                 </a>
                             </div>
                             <div class="col-md-4">
-                                <a href="https://laravelvoyager.com" target="_blank" class="voyager-link" style="background-image:url('{{ voyager_asset('images/compass/voyager-home.jpg') }}')">
+                                <a href="https://voyager.devdojo.com/" target="_blank" class="voyager-link" style="background-image:url('{{ voyager_asset('images/compass/voyager-home.jpg') }}')">
                                     <span class="resource_label"><i class="voyager-browser"></i> <span class="copy">{{ __('voyager::compass.links.voyager_homepage') }}</span></span>
                                 </a>
                             </div>


### PR DESCRIPTION
In relation to issue 5411 (https://github.com/the-control-group/voyager/issues/5411#issue-954947736)
Offending URL - https://docs.laravelvoyager.com/

Closes #5411