### PR TITLE
bugfix cannot count json in php 8

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -145,7 +145,7 @@
                                                     @endif
 
                                                     @elseif($row->type == 'multiple_checkbox' && property_exists($row->details, 'options'))
-                                                        @if (@count(json_decode($data->{$row->field})) > 0)
+                                                        @if (@count(json_decode($data->{$row->field}, true)) > 0)
                                                             @foreach(json_decode($data->{$row->field}) as $item)
                                                                 @if (@$row->details->options->{$item})
                                                                     {{ $row->details->options->{$item} . (!$loop->last ? ', ' : '') }}


### PR DESCRIPTION
Error Message Bug :

count(): Argument #1 ($value) must be of type Countable|array, stdClass given (View: C:\inetpub\project\releases\v2.0.1\vendor\tcg\voyager\resources\views\bread\browse.blade.php) {"view":{"view":"C:\\inetpub\\project\ eleases\\v2.0.1\\vendor\\tcg\\voyager\\src/../resources/views/bread/browse.blade.php","data":{"errors":"<pre class=sf-dump id=sf-dump-2123317758 data-indent-pad=\" \"><span class=sf-dump-note>Illuminate\\Support\\ViewErrorBag</span> {<a class=sf-dump-ref>#474</a><samp data-depth=1 class=sf-dump-expanded>