### PR TITLE
Fix media picker delete thumbnails

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -142,6 +142,15 @@ class VoyagerMediaController extends Controller
                 $error = __('voyager::media.error_deleting_file');
                 $success = false;
             }
+
+            if (!empty($file['thumbnails'])) {
+                foreach ($file['thumbnails'] as $thumbnail) {
+                    if ($thumbnail['type'] == 'file') {
+                        $thumbnail_path = $path.$thumbnail['basename'];
+                        Storage::disk($this->filesystem)->delete($thumbnail_path);
+                    }
+                }
+            }
         }
 
         return compact('success', 'error');


### PR DESCRIPTION
'thumbnails' was already in the request. Simple hooked this up with the file delete. 

Fixes issue:
https://github.com/the-control-group/voyager/issues/4980