### PR TITLE
Add "use_intervention" option in config, for an uploaded images in media manager.

### DIFF
--- a/publishable/config/voyager.php
+++ b/publishable/config/voyager.php
@@ -239,6 +239,7 @@ return [
         'allow_delete'        => true,
         'allow_create_folder' => true,
         'allow_rename'        => true,
+        'use_intervention'    => true,
         /*'watermark'           => [
             'source'         => 'watermark.png',
             'position'       => 'bottom-left',

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -259,7 +259,7 @@ class VoyagerMediaController extends Controller
                 'image/bmp',
                 'image/svg+xml',
             ];
-            if (in_array($request->file->getMimeType(), $imageMimeTypes) && config('voyager.media.use_intervention') {
+            if (in_array($request->file->getMimeType(), $imageMimeTypes) && config('voyager.media.use_intervention')) {
                 $content = Storage::disk($this->filesystem)->get($file);
                 $image = Image::make($content);
 

--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -259,7 +259,7 @@ class VoyagerMediaController extends Controller
                 'image/bmp',
                 'image/svg+xml',
             ];
-            if (in_array($request->file->getMimeType(), $imageMimeTypes)) {
+            if (in_array($request->file->getMimeType(), $imageMimeTypes) && config('voyager.media.use_intervention') {
                 $content = Storage::disk($this->filesystem)->get($file);
                 $image = Image::make($content);
 
@@ -271,7 +271,6 @@ class VoyagerMediaController extends Controller
                     if (property_exists($details, 'thumbnails') && is_array($details->thumbnails)) {
                         foreach ($details->thumbnails as $thumbnail_data) {
                             $type = $thumbnail_data->type ?? 'fit';
-                            $thumbnail = Image::make(clone $image);
                             if ($type == 'fit') {
                                 $thumbnail = $thumbnail->fit(
                                     $thumbnail_data->width,


### PR DESCRIPTION
Voyager uses intervention to make the images for each upload request in the media manager, but there are no options to stop this process.
I added a new key to a media config that allows us to determine if we want to compress the images or not. 