### PR TITLE
Fix missing space between attributes

### DIFF
--- a/src/Actions/AbstractAction.php
+++ b/src/Actions/AbstractAction.php
@@ -37,13 +37,13 @@ abstract class AbstractAction implements ActionInterface
 
     public function convertAttributesToHtml()
     {
-        $result = '';
+        $result = [];
 
         foreach ($this->getAttributes() as $key => $attribute) {
-            $result .= $key.'="'.$attribute.'"';
+            $result[] = sprintf('%s="%s"', $key, $attribute);
         }
 
-        return $result;
+        return implode(" ", $result);
     }
 
     public function shouldActionDisplayOnDataType()


### PR DESCRIPTION
fixed missing space between attributes when there is more than one attributes.

It was generating something like this:
class="btn btn-sm btn-info"id="222"