### PR TITLE
No need to call date() twice.

### DIFF
--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -40,7 +40,7 @@ class VoyagerController extends Controller
             abort(403);
         }
 
-        $path = $slug.'/'.date('F').date('Y').'/';
+        $path = $slug.'/'.date('FY').'/';
 
         $filename = basename($file->getClientOriginalName(), '.'.$file->getClientOriginalExtension());
         $filename_counter = 1;


### PR DESCRIPTION
I have removed the `date('Y')` because we can use one date method to approach the same thing.