### PR TITLE
Add Custom Path feature to Formfield File

### DIFF
--- a/src/Http/Controllers/ContentTypes/File.php
+++ b/src/Http/Controllers/ContentTypes/File.php
@@ -44,6 +44,9 @@ class File extends BaseType
      */
     protected function generatePath()
     {
+        if (isset($this->options->custom_path)) {
+            return $this->options->custom_path.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
+        }
         return $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
     }
 


### PR DESCRIPTION
With this feature is now possible to say where the file must be stored. 

Simple put this in the optional details and it will be saved in that folder:
```
{
    "custom_path": "mypathname"
}
```