### PR TITLE
Get translated relationships with translation API

### DIFF
--- a/src/Traits/Translatable.php
+++ b/src/Traits/Translatable.php
@@ -12,6 +12,16 @@ use TCG\Voyager\Translator;
 trait Translatable
 {
     /**
+     * Access the model eager loaded relationships
+     *
+     * @return array
+     */
+    public function getEagerRelations()
+    {
+        return $this->with;
+    }
+
+    /**
      * Check if this model can translate.
      *
      * @return bool

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -43,6 +43,20 @@ class Translator implements ArrayAccess, JsonSerializable
             $this->translateAttribute($attribute, $locale, $fallback);
         }
 
+        if(request()->is('api/*') && request()->isMethod('GET') || request()->wantsJson()) {
+
+            $relations = [];
+            
+            foreach ($this->model->getEagerRelations() as $relation) {
+                $relations[$relation] = !empty($this->model->$relation->toArray()) && Voyager::translatable(get_class($this->model->$relation->first())) ? $this->model->$relation->translate($locale, $fallback) : $this->model->$relation;
+            }
+            
+            $data = collect($this)->merge($relations);
+            
+            return $data;
+            
+        }
+
         return $this;
     }
 


### PR DESCRIPTION
A suggested fix for issue #5521 

- A modification to the translatable trait to access the protected $with attribute for the translatable model
- A modification to the Translator model to check for eagerly loaded relationships and translating them accordingly