### PR TITLE
fixes: fixed json_decode(): Passing null to parameter of type string …

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -32,7 +32,7 @@ class User extends Authenticatable implements UserContract
 
     public function getSettingsAttribute($value)
     {
-        return collect(json_decode($value));
+        return $value ? collect(json_decode($value)) : collect();
     }
 
     public function setLocaleAttribute($value)


### PR DESCRIPTION
…is deprecated