### PR TITLE
Throw exception if dataType not found when checking permissions

### DIFF
--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -82,7 +82,7 @@ class BasePolicy
         }
 
         if (!self::$datatypes[$model_name]) {
-            throw new \Exception("Unable to find model: " . $model_name);
+            throw new \Exception("Unable to find dataType with model: " . $model_name);
         }
 
         $dataType = self::$datatypes[$model_name];

--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -75,12 +75,17 @@ class BasePolicy
      */
     protected function checkPermission(User $user, $model, $action)
     {
-        if (!isset(self::$datatypes[get_class($model)])) {
+        $model_name = get_class($model);
+        if (!isset(self::$datatypes[$model_name])) {
             $dataType = Voyager::model('DataType');
-            self::$datatypes[get_class($model)] = $dataType->where('model_name', get_class($model))->first();
+            self::$datatypes[$model_name] = $dataType->where('model_name', $model_name)->first();
         }
 
-        $dataType = self::$datatypes[get_class($model)];
+        if (!self::$datatypes[$model_name]) {
+            throw new \Exception("Unable to find model: " . $model_name);
+        }
+
+        $dataType = self::$datatypes[$model_name];
 
         return $user->hasPermission($action.'_'.$dataType->name);
     }


### PR DESCRIPTION
Provide useful error instead of: Attempt to read property "name" on null