### PR TITLE
fix json_decode(): Passing null to parameter #1 ($json) of type string is deprecated at User and MenuItem models

### DIFF
--- a/src/Models/MenuItem.php
+++ b/src/Models/MenuItem.php
@@ -90,7 +90,7 @@ class MenuItem extends Model
 
     public function getParametersAttribute()
     {
-        return json_decode($this->attributes['parameters']);
+        return json_decode(!empty($this->attributes['parameters']) ? $this->attributes['parameters'] : '{}');
     }
 
     public function setParametersAttribute($value)

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -32,7 +32,7 @@ class User extends Authenticatable implements UserContract
 
     public function getSettingsAttribute($value)
     {
-        return collect(json_decode($value) ?? '');
+        return collect(json_decode(!empty($value) ? $value : '{}'));
     }
 
     public function setLocaleAttribute($value)

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -32,7 +32,7 @@ class User extends Authenticatable implements UserContract
 
     public function getSettingsAttribute($value)
     {
-        return collect(json_decode($value));
+        return collect(json_decode($value) ?? '');
     }
 
     public function setLocaleAttribute($value)


### PR DESCRIPTION
Fix based on my issue https://github.com/the-control-group/voyager/issues/5603