### PR TITLE
Enable html tag for Custom relationship attributes

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -107,7 +107,7 @@
                 @if($query->isNotEmpty())
                     <ul>
                         @foreach($query as $query_res)
-                            <li>{{ $query_res->{$options->label} }}</li>
+                            <li>{!! $query_res->{$options->label} !!}</li>
                         @endforeach
                     </ul>
                 @else

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -83,7 +83,7 @@
                     @if(empty($selected_values))
                         <p>{{ __('voyager::generic.no_results') }}</p>
                     @else
-                        <p>{{ $string_values }}</p>
+                        <p>{!! $string_values !!}</p>
                     @endif
                 @else
                     @if(empty($selected_values))
@@ -91,7 +91,7 @@
                     @else
                         <ul>
                             @foreach($selected_values as $selected_value)
-                                <li>{{ $selected_value }}</li>
+                                <li>{!! $selected_value !!}</li>
                             @endforeach
                         </ul>
                     @endif


### PR DESCRIPTION
We define a Custom relationship attributes,
We can add html tags in this attribute, like (i've added space in the tag and html entities to avoid this editor to read them)
          $this->titre."< br / >".$this->journal."& nbsp;& nbsp;-& nbsp;& nbsp;".$this->auteur."< br / >&nbsp;"

In order for the tags to be correctly interpreted in the edit bread view, we change {{ ... }} to {!! ...!}} in voyager/resources/views/formfield/relationship.blade.php