### PR TITLE
Bread - Browse and Read for MediaPicker

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -246,12 +246,14 @@
                                                         {{ trans_choice('voyager::media.files', 0) }}
                                                     @elseif ($data->{$row->field} != '')
                                                         @if (property_exists($row->details, 'show_as_images') && $row->details->show_as_images)
-                                                            @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$data->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
-                                                                <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:50px">
-                                                            @else
-                                                                <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$data->{$row->field} ?: '' }}" target="_blank">
-                                                                    {{ __('voyager::generic.download') }}
-                                                                </a>
+															@if (file_exists(Storage::disk(config('voyager.storage.disk'))->path('').$data->{$row->field}))
+                                                                @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$data->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
+                                                                    <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:50px">
+                                                                @else
+                                                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$data->{$row->field} ?: '' }}" target="_blank">
+                                                                        {{ __('voyager::generic.download') }}
+                                                                    </a>
+                                                                @endif
                                                             @endif
                                                         @else
                                                             {{ $data->{$row->field} }}

--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -223,7 +223,14 @@
                                                     @if ($files)
                                                         @if (property_exists($row->details, 'show_as_images') && $row->details->show_as_images)
                                                             @foreach (array_slice($files, 0, 3) as $file)
-                                                            <img src="@if( !filter_var($file, FILTER_VALIDATE_URL)){{ Voyager::image( $file ) }}@else{{ $file }}@endif" style="width:50px">
+                                                                {{ Storage::disk(config('voyager.storage.disk'))->path('').$file }}
+                                                                @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$file), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
+                                                                    <img src="@if( !filter_var($file, FILTER_VALIDATE_URL)){{ Voyager::image( $file ) }}@else{{ $file }}@endif" style="width:50px">
+                                                                @else
+                                                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$file ?: '' }}" target="_blank">
+                                                                        {{ __('voyager::generic.download') }}
+                                                                    </a>
+                                                                @endif
                                                             @endforeach
                                                         @else
                                                             <ul>
@@ -239,7 +246,13 @@
                                                         {{ trans_choice('voyager::media.files', 0) }}
                                                     @elseif ($data->{$row->field} != '')
                                                         @if (property_exists($row->details, 'show_as_images') && $row->details->show_as_images)
-                                                            <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:50px">
+                                                            @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$data->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
+                                                                <img src="@if( !filter_var($data->{$row->field}, FILTER_VALIDATE_URL)){{ Voyager::image( $data->{$row->field} ) }}@else{{ $data->{$row->field} }}@endif" style="width:50px">
+                                                            @else
+                                                                <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$data->{$row->field} ?: '' }}" target="_blank">
+                                                                    {{ __('voyager::generic.download') }}
+                                                                </a>
+                                                            @endif
                                                         @else
                                                             {{ $data->{$row->field} }}
                                                         @endif

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -66,6 +66,15 @@
                                     <img class="img-responsive"
                                          src="{{ filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL) ? $dataTypeContent->{$row->field} : Voyager::image($dataTypeContent->{$row->field}) }}">
                                 @endif
+                            @elseif($row->type == "media_picker")
+                                @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$dataTypeContent->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
+                                    <img class="img-responsive"
+                                        src="{{ filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL) ? $dataTypeContent->{$row->field} : Voyager::image($dataTypeContent->{$row->field}) }}" />
+                                @else
+                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$dataTypeContent->{$row->field} ?: '' }}">
+                                        {{ __('voyager::generic.download') }}
+                                    </a>
+                                @endif
                             @elseif($row->type == 'relationship')
                                  @include('voyager::formfields.relationship', ['view' => 'read', 'options' => $row->details])
                             @elseif($row->type == 'select_dropdown' && property_exists($row->details, 'options') &&
@@ -116,13 +125,13 @@
                             @elseif($row->type == 'file')
                                 @if(json_decode($dataTypeContent->{$row->field}))
                                     @foreach(json_decode($dataTypeContent->{$row->field}) as $file)
-                                        <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($file->download_link) ?: '' }}">
+                                        <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($file->download_link) ?: '' }}" target="_blank">
                                             {{ $file->original_name ?: '' }}
                                         </a>
                                         <br/>
                                     @endforeach
                                 @elseif($dataTypeContent->{$row->field})
-                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($row->field) ?: '' }}">
+                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($row->field) ?: '' }}" target="_blank">
                                         {{ __('voyager::generic.download') }}
                                     </a>
                                 @endif

--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -67,13 +67,15 @@
                                          src="{{ filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL) ? $dataTypeContent->{$row->field} : Voyager::image($dataTypeContent->{$row->field}) }}">
                                 @endif
                             @elseif($row->type == "media_picker")
-                                @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$dataTypeContent->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
-                                    <img class="img-responsive"
-                                        src="{{ filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL) ? $dataTypeContent->{$row->field} : Voyager::image($dataTypeContent->{$row->field}) }}" />
-                                @else
-                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$dataTypeContent->{$row->field} ?: '' }}">
-                                        {{ __('voyager::generic.download') }}
-                                    </a>
+                                @if (file_exists(Storage::disk(config('voyager.storage.disk'))->path('').$dataTypeContent->{$row->field}))
+                                    @if (in_array(mime_content_type(Storage::disk(config('voyager.storage.disk'))->path('').$dataTypeContent->{$row->field}), ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/vnd.microsoft.icon', 'image/tiff', 'image/svg+xml']))
+                                        <img class="img-responsive"
+                                            src="{{ filter_var($dataTypeContent->{$row->field}, FILTER_VALIDATE_URL) ? $dataTypeContent->{$row->field} : Voyager::image($dataTypeContent->{$row->field}) }}" />
+                                    @else
+                                        <a href="{{ Storage::disk(config('voyager.storage.disk'))->url('').$dataTypeContent->{$row->field} ?: '' }}">
+                                            {{ __('voyager::generic.download') }}
+                                        </a>
+                                    @endif
                                 @endif
                             @elseif($row->type == 'relationship')
                                  @include('voyager::formfields.relationship', ['view' => 'read', 'options' => $row->details])

--- a/resources/views/formfields/media_picker.blade.php
+++ b/resources/views/formfields/media_picker.blade.php
@@ -22,7 +22,16 @@
                 :element="'input[name=&quot;{{ $row->field }}&quot;]'"
                 :details="{{ json_encode($options ?? []) }}"
             ></media-manager>
-            <input type="hidden" :value="{{ $content }}" name="{{ $row->field }}">
+			@php
+				$path = substr($content, 1, strlen($content)-1);
+				$path = substr($path, 0, strlen($path)-1);
+				$path = Storage::disk(config('voyager.storage.disk'))->path('').$path;
+			@endphp
+			@if (file_exists($path))
+				<input type="hidden" :value="{{ $content }}" name="{{ $row->field }}">
+			@else
+				<input type="hidden" :value="''" name="{{ $row->field }}">
+			@endif
         </div>
     </div>
 </div>


### PR DESCRIPTION
Depends on the mimetype of the media/file, displays the image or the Download link for media picker field.

In the browse and read view, "Couverture" is a Media picker with an image, "Pdf complet" is a Media picker with a pdf file, with the download link.

![image](https://user-images.githubusercontent.com/104444110/185587509-b626e363-0ae6-4e10-ac14-5488ed634531.png)

![image](https://user-images.githubusercontent.com/104444110/185587421-37cef358-4c04-4175-acdc-dd03d43a7c84.png)
