### PR TITLE
Enable flag sort for relationship (natural, regular, numeric, string, ...)

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -945,10 +945,14 @@ class VoyagerBaseController extends Controller
 
                 // Sort results
                 if (!empty($options->sort->field)) {
+                    $sort = SORT_REGULAR;
+                    if (!empty($options->sort->flag)) {
+                        $sort = str_replace('"', '', $options->sort->flag);
+                    }
                     if (!empty($options->sort->direction) && strtolower($options->sort->direction) == 'desc') {
-                        $relationshipOptions = $relationshipOptions->sortByDesc($options->sort->field);
+                        $relationshipOptions = $relationshipOptions->sortByDesc($options->sort->field, $sort);
                     } else {
-                        $relationshipOptions = $relationshipOptions->sortBy($options->sort->field);
+                        $relationshipOptions = $relationshipOptions->sortBy($options->sort->field, $sort);
                     }
                 }
 


### PR DESCRIPTION
Before, without sort flag
![image](https://user-images.githubusercontent.com/104444110/185622713-c2a6366b-3bec-4071-8eaa-9426ff45277a.png)

After with sort flag set to 6
![image](https://user-images.githubusercontent.com/104444110/185622859-8ab47b83-c1bc-4517-8d7a-00f878458e73.png)


In the bread relationship, add "flag" relation detail
![image](https://user-images.githubusercontent.com/104444110/185621716-1ad44766-608b-4729-9e83-6b1e3da8afb8.png)

the sortBy and sortByDesc needs an integer
It's not possible to put "SORT_REGULAR" in the "flag" relation detail json, because it's string
So, the possible integer values for the "flag" relation detail json are
SORT_REGULAR)          ==> 0
SORT_NUMERIC           == >1
SORT_STRING               ==> 2
SORT_LOCALE_STRING ==> 5
SORT_NATURAL            ==> 6
SORT_FLAG_CASE         ==> 8
