### PR TITLE
Fix typo in funding.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [tnylea, fletch3555, emptynick]# Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [tnylea, fletch3555, emptynick]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username


### PR DESCRIPTION
This was causing a visual glitch on packagist:
![image](https://user-images.githubusercontent.com/4985291/188175874-8fb6bacf-394a-46b6-bc19-f71d598c3ddf.png)
