### PR TITLE
Prevent 404 error from Voyager assets when all controllers are copied

### DIFF
--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -84,11 +84,11 @@ class VoyagerController extends Controller
         try {
             if (class_exists(\League\Flysystem\Util::class)) {
                 // Flysystem 1.x
-                $path = dirname(__DIR__, 3).'/publishable/assets/'.\League\Flysystem\Util::normalizeRelativePath(urldecode($request->path));
+                $path = base_path() . '/vendor/tcg/voyager/publishable/assets/'.\League\Flysystem\Util::normalizeRelativePath(urldecode($request->path));
             } elseif (class_exists(\League\Flysystem\WhitespacePathNormalizer::class)) {
                 // Flysystem >= 2.x
                 $normalizer = new \League\Flysystem\WhitespacePathNormalizer();
-                $path = dirname(__DIR__, 3).'/publishable/assets/'. $normalizer->normalizePath(urldecode($request->path));
+                $path = base_path() . '/vendor/tcg/voyager/publishable/assets/'. $normalizer->normalizePath(urldecode($request->path));
             }
             
         } catch (\LogicException $e) {


### PR DESCRIPTION
When voyager controllers are copied into the main application (app\Http\Controllers\Voyager, for example), in particular the VoyagerController.php and Voyager controllers directory is updated in the configuration file config/voyager.php ( \\TCG\\Voyager\\Http\\Controllers to \\App\\Http\\Controllers\\Voyager, for example), Voyager assets stop working (404 error). Commit allows assets to continue to be found regardless of where controllers are