### PR TITLE
Fix custom attribute not working on Relationship (#5441)

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -180,7 +180,7 @@
                                 )->pluck($options->table.'.'.$options->key);
                             }
                             $selected_keys = old($relationshipField, $selected_keys);
-                            $selected_values = app($options->model)->whereIn($options->key, $selected_keys)->pluck($options->label, $options->key);
+                            $selected_values = app($options->model)->whereIn($options->key, $selected_keys)->get()->pluck($options->label, $options->key);
                         @endphp
 
                         @if(!$row->required)


### PR DESCRIPTION
**Fix custom attribute not working on Relationship**

Implement a solution from https://stackoverflow.com/a/47781344/10861398.

This PR fixes an issue where the custom attribute was not working correctly on the Relationship form field. The code has been modified to retrieve the selected values using the `get()` method before plucking the label and key. This ensures that the custom attribute works as expected. 

Fixes #5441