### PR TITLE
Improve Rich text box read view using TinyMCE Readonly mode

### DIFF
--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -112,7 +112,9 @@
                                 @include('voyager::partials.coordinates')
                             @elseif($row->type == 'rich_text_box')
                                 @include('voyager::multilingual.input-hidden-bread-read')
-                                {!! $dataTypeContent->{$row->field} !!}
+                                @include('voyager::formfields.rich_text_box', [
+                                    'view' => 'read',
+                                ])
                             @elseif($row->type == 'file')
                                 @if(json_decode($dataTypeContent->{$row->field}))
                                     @foreach(json_decode($dataTypeContent->{$row->field}) as $file)

--- a/resources/views/formfields/rich_text_box.blade.php
+++ b/resources/views/formfields/rich_text_box.blade.php
@@ -9,7 +9,12 @@
                 selector: 'textarea.richTextBox[name="{{ $row->field }}"]',
             }
 
-            $.extend(additionalConfig, {!! json_encode($options->tinymceOptions ?? (object)[]) !!})
+            if ("{{ $view ?? null }}" === 'read') {
+                additionalConfig.toolbar = false
+                additionalConfig.readonly = true
+            }
+
+            $.extend(additionalConfig, {!! json_encode($options->tinymceOptions ?? (object) []) !!})
 
             tinymce.init(window.voyagerTinyMCE.getConfig(additionalConfig));
         });

--- a/resources/views/multilingual/input-hidden-bread-read.blade.php
+++ b/resources/views/multilingual/input-hidden-bread-read.blade.php
@@ -3,5 +3,5 @@
            data-i18n="true"
            name="{{ $row->field }}_i18n"
            id="{{ $row->field }}_i18n"
-           value="{{ get_field_translations($dataTypeContent, $row->field, $row->type, true) }}">
+           value="{{ get_field_translations($dataTypeContent, $row->field, $row->type) }}">
 @endif


### PR DESCRIPTION
# Description

Instead of displaying the rich text box data as it is (HTML String), please use the default [TinyMCE Readonly mode](https://www.tiny.cloud/docs/tinymce/6/editor-important-options/#readonly) to keep the consistency between add/edit & read page.

## Before

![image](https://user-images.githubusercontent.com/39755201/209538522-c88f7851-d052-4c00-a192-e27843a3d281.png)


## After

- There's no overlapping style with Voyager Admin CSS
- Consistency style between add/edit & read page
- There's no TinyMCE Toolbar

![image](https://user-images.githubusercontent.com/39755201/209538145-68c2380f-2963-4f92-952a-64d538dc8939.png)

# Related Issues

- Closes #5596
- #3706
- #3313

@emptynick @MrCrayon 