### PR TITLE
Bad quote in doc example

### DIFF
--- a/docs/core-concepts/roles-and-permissions.md
+++ b/docs/core-concepts/roles-and-permissions.md
@@ -56,7 +56,7 @@ You may create your own [gate](https://laravel.com/docs/authorization#gates)
 
 ```php
 Gate::define('browse_create_bill', function ($user) {
-    return $user->hasPermission(`browse_create_bill`);
+    return $user->hasPermission('browse_create_bill');
 });
 ```
     


### PR DESCRIPTION
In the doc https://voyager-docs.devdojo.com/core-concepts/roles-and-permissions#customize-controller, be carefull with the example.
I checked for some hours to know why it was not working !
It's because bad ` in place of good '