### PR TITLE
Fix: File field on read view (single file) should show field value (filename), not field name

### DIFF
--- a/resources/views/bread/read.blade.php
+++ b/resources/views/bread/read.blade.php
@@ -122,7 +122,7 @@
                                         <br/>
                                     @endforeach
                                 @elseif($dataTypeContent->{$row->field})
-                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($row->field) ?: '' }}">
+                                    <a href="{{ Storage::disk(config('voyager.storage.disk'))->url($dataTypeContent->{$row->field}) ?: '' }}">
                                         {{ __('voyager::generic.download') }}
                                     </a>
                                 @endif


### PR DESCRIPTION
There's an error on Read view where file fields with a single value (not using array notation) are currently showing incorrectly a download link with the field name as href, not the correct field value.

This pull request fixes this error.