### PR TITLE
Fix server side relationship search

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -47,13 +47,6 @@ class VoyagerBaseController extends Controller
 
         $search = (object) ['value' => $request->get('s'), 'key' => $request->get('key'), 'filter' => $request->get('filter')];
 
-        $searchNames = [];
-        if ($dataType->server_side) {
-            $searchNames = $dataType->browseRows->mapWithKeys(function ($row) {
-                return [$row['field'] => $row->getTranslatedAttribute('display_name')];
-            });
-        }
-
         $orderBy = $request->get('order_by', $dataType->order_column);
         $sortOrder = $request->get('sort_order', $dataType->order_direction);
         $usesSoftDeletes = false;
@@ -126,6 +119,13 @@ class VoyagerBaseController extends Controller
             // If Model doesn't exist, get data from table name
             $dataTypeContent = call_user_func([DB::table($dataType->name), $getter]);
             $model = false;
+        }
+        
+        $searchNames = [];
+        if ($dataType->server_side) {
+            $searchNames = $dataType->browseRows->mapWithKeys(function ($row) {
+                return [$row['field'] => $row->getTranslatedAttribute('display_name')];
+            });
         }
 
         // Check if BREAD is Translatable

--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -981,6 +981,8 @@ class VoyagerBaseController extends Controller
 
             return !$this->relationIsUsingAccessorAsLabel($item->details);
         })->first();
+
+        if(!$row) return $row;
         
         $relation = $row->details->relation ?? \Str::camel(class_basename(app($row->details->model)));
 


### PR DESCRIPTION
### This fixes the issue with Voyager's server side searching.

This potentially fixes #5645 #5635 #5433 #5412 

This issue can be recreated by enabling Server-side Pagination in BREAD and then having a relationship field.

![server-side](https://user-images.githubusercontent.com/5493673/229594634-9fbe3580-f753-48b9-8f78-268a22c8bbc5.png)

![relationship](https://user-images.githubusercontent.com/5493673/229595194-2cc16b83-1823-4c83-86b2-4d2be26fbbdd.png)

Now upon searching the relationship field in browse view, an exception occurs.

![searching-role](https://user-images.githubusercontent.com/5493673/229595036-f01f43c3-8c44-413d-9975-ca07c82f8f78.png)

![exception](https://user-images.githubusercontent.com/5493673/229597428-ce64ecef-7335-4013-808c-6b939eb763bb.png)

### This fixes  fixes duplicate filter field occurance and enables multiple relationship fields sharing same reference column

This also fixes the duplicate filter dropdown entries when there is a non-relation field sharing the same name with a relationship reference column name in the same BREAD.

![bread-fields-duplicate](https://user-images.githubusercontent.com/5493673/229600037-9bf55047-f09a-47af-b236-30fd17616092.png)

![search-keys-repeats](https://user-images.githubusercontent.com/5493673/229600058-938e37ec-f4ef-4bcb-9ccf-8cc19d51c373.png)

Note that this will not affect multiple relation fields in a BREAD sharing the same relationship reference column name (but different display column for instance).

### This allows use of custom relationship methods in eloquent models

If you are using a custom relationship method in your eloquent model, you can mention that method name in Relationship Details as long as you have specified your model in BREAD.

```
public function group()
{
    return $this->belongsTo(\TCG\Voyager\Facades\Voyager::modelClass('Role'), 'role_id');
}
```

![customize-model](https://user-images.githubusercontent.com/5493673/229605609-4a19d349-44e9-4af6-bca6-3ce96385e4a7.png)

![custom-relation](https://user-images.githubusercontent.com/5493673/229605623-6181b462-db68-4bec-a875-4ea5001831b8.png)

If a name is not specified, the relationship method name will be determined from the model name.