### PR TITLE
Keep original media filename after upload with Media Picker

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -240,8 +240,10 @@ class VoyagerMediaController extends Controller
             }
 
             if (!$request->has('filename') || $request->get('filename') == 'null') {
-                while (Storage::disk($this->filesystem)->exists(Str::finish($request->upload_path, '/').$name.'.'.$extension, $this->filesystem)) {
-                    $name = get_file_name($name);
+                if (!$details->preserveFileUploadName) {
+                    while (Storage::disk($this->filesystem)->exists(Str::finish($request->upload_path, '/').$name.'.'.$extension, $this->filesystem)) {
+                        $name = get_file_name($name);
+                    }
                 }
             } else {
                 $name = str_replace('{uid}', Auth::user()->getKey(), $request->get('filename'));


### PR DESCRIPTION
Related to https://github.com/the-control-group/voyager/issues/2173

Just add in the bread field name options : 
{
"preserveFileUploadName": "yes"
}

![image](https://github.com/the-control-group/voyager/assets/104444110/2fe16147-5121-4f6d-a5af-69c1d1c61578)
