### PR TITLE
Remove validation of BREAD when the request is of tagging

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -444,7 +444,9 @@ class VoyagerBaseController extends Controller
         $this->authorize('add', app($dataType->model_name));
 
         // Validate fields with ajax
-        $val = $this->validateBread($request->all(), $dataType->addRows)->validate();
+        if (!$request->has('_tagging')) {
+            $val = $this->validateBread($request->all(), $dataType->addRows)->validate();
+        }
         $data = $this->insertUpdateData($request, $slug, $dataType->addRows, new $dataType->model_name());
 
         event(new BreadDataAdded($dataType, $data));


### PR DESCRIPTION
I was working with tags in a model and suddenly it stopped working.

After some research I found that Voyager was trying to use the same validation rules that were in the BREAD of my tag model.

As the tag creation will try to pass only the display column, I don't think it should go through the BREAD validation.

This pull request will keep the BREAD validation only when the request is not of tagging.