### PR TITLE
Fix/rich text display browse mode

### DIFF
--- a/resources/views/bread/browse.blade.php
+++ b/resources/views/bread/browse.blade.php
@@ -116,7 +116,8 @@
                                             @php
                                             if ($data->{$row->field.'_browse'}) {
                                                 $data->{$row->field} = $data->{$row->field.'_browse'};
-                                            }
+                                            } 
+                                            $data->{$row->field} = cleanText($data->{$row->field});
                                             @endphp
                                             <td>
                                                 @if (isset($row->details->view_browse))

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -15,7 +15,7 @@
                 @endphp
 
                 @if(isset($query))
-                    <p>{{ $query->{$options->label} }}</p>
+                     <p>{{ cleanText($query->{$options->label}) }}</p>
                 @else
                     <p>{{ __('voyager::generic.no_results') }}</p>
                 @endif
@@ -57,7 +57,7 @@
             @endphp
 
             @if(isset($query))
-                <p>{{ $query->{$options->label} }}</p>
+                 <p>{{ cleanText($query->{$options->label}) }}</p>
             @else
                 <p>{{ __('voyager::generic.no_results') }}</p>
             @endif
@@ -83,7 +83,7 @@
                     @if(empty($selected_values))
                         <p>{{ __('voyager::generic.no_results') }}</p>
                     @else
-                        <p>{{ $string_values }}</p>
+                        <p>{{ cleanText($string_values) }}</p>
                     @endif
                 @else
                     @if(empty($selected_values))
@@ -136,7 +136,7 @@
                     @if(empty($selected_values))
                         <p>{{ __('voyager::generic.no_results') }}</p>
                     @else
-                        <p>{{ $string_values }}</p>
+                        <p>{{ cleanText($string_values) }}</p>
                     @endif
                 @else
                     @if(empty($selected_values))

--- a/src/Helpers/helpers.php
+++ b/src/Helpers/helpers.php
@@ -17,7 +17,7 @@ if (!function_exists('menu')) {
 if (!function_exists('voyager_asset')) {
     function voyager_asset($path, $secure = null)
     {
-        return route('voyager.voyager_assets').'?path='.urlencode($path);
+        return route('voyager.voyager_assets') . '?path=' . urlencode($path);
     }
 }
 
@@ -26,9 +26,18 @@ if (!function_exists('get_file_name')) {
     {
         preg_match('/(_)([0-9])+$/', $name, $matches);
         if (count($matches) == 3) {
-            return Illuminate\Support\Str::replaceLast($matches[0], '', $name).'_'.(intval($matches[2]) + 1);
+            return Illuminate\Support\Str::replaceLast($matches[0], '', $name) . '_' . (intval($matches[2]) + 1);
         } else {
-            return $name.'_1';
+            return $name . '_1';
         }
+    }
+}
+
+if (!function_exists('cleanText')) {
+    function cleanText($text)
+    {
+        $removedTags = preg_replace('/<[^>]*>/', '', $text);
+        $cleanedText = html_entity_decode($removedTags);
+        return $cleanedText;
     }
 }


### PR DESCRIPTION
## Pull Request: Fix Showing HTML Elements and HTML Entities in Browse Mode

### Description
This pull request resolves an issue where HTML elements and entities were being displayed in their raw form in browse mode when rendering rich text content. The problem led to an unformatted and confusing user experience.

### Changes Made
- Implemented a fix to properly render rich text content, displaying it as intended in browse mode.
- Ensured that HTML elements and entities are now displayed as rendered content, improving the user experience.

### How to Test
1. Navigate to a page with a rich text field (of itself or its relations) in browse mode.
2. Verify that HTML tags and entities are now removed, rather than being displayed as raw code.
3. Confirm that the rich text content appears as intended and is easy to read.

### Additional Notes
This fix enhances the user experience by ensuring that rich text preview is correctly displayed in browse mode. 
Your review and feedback are highly appreciated.

Please review and test these changes to ensure they address the issue effectively.
