### PR TITLE
Fix oldName column option not supported error

### DIFF
--- a/src/Database/Schema/Column.php
+++ b/src/Database/Schema/Column.php
@@ -15,7 +15,7 @@ abstract class Column
         $type = ($type instanceof DoctrineType) ? $type : DoctrineType::getType(trim($type['name']));
         $type->tableName = $tableName;
 
-        $options = array_diff_key($column, ['name' => $name, 'type' => $type]);
+        $options = array_diff_key($column, array_flip(['name', 'composite', 'oldName', 'null', 'extra', 'type', 'charset', 'collation']));
 
         return new DoctrineColumn($name, $type, $options);
     }


### PR DESCRIPTION
Fixes the bug described here:

Closes #5766