### PR TITLE
 add meta Content-Security-Policy to force upgrade-insecure-requests

### DIFF
--- a/resources/views/auth/master.blade.php
+++ b/resources/views/auth/master.blade.php
@@ -6,6 +6,7 @@
     <meta name="robots" content="none" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=0, minimal-ui">
     <meta name="description" content="admin login">
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <title>@yield('title', 'Admin - '.Voyager::setting("admin.title"))</title>
     <link rel="stylesheet" href="{{ voyager_asset('css/app.css') }}">
     @if (__('voyager::generic.is_rtl') == 'true')

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}"/>
     <meta name="assets-path" content="{{ route('voyager.voyager_assets') }}"/>
-
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
 


### PR DESCRIPTION
This PR is to prevent this error : 

Mixed Content: The page at 'X' was loaded over HTTPS, but requested an insecure element (HTTP)