### PR TITLE
Image location url changed to custom format from %monthyear%

### DIFF
--- a/src/Http/Controllers/ContentTypes/File.php
+++ b/src/Http/Controllers/ContentTypes/File.php
@@ -44,7 +44,7 @@ class File extends BaseType
      */
     protected function generatePath()
     {
-        return $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
+        return $this->slug.DIRECTORY_SEPARATOR;
     }
 
     /**

--- a/src/Http/Controllers/ContentTypes/Image.php
+++ b/src/Http/Controllers/ContentTypes/Image.php
@@ -14,7 +14,7 @@ class Image extends BaseType
         if ($this->request->hasFile($this->row->field)) {
             $file = $this->request->file($this->row->field);
 
-            $path = $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
+            $path = $this->slug.DIRECTORY_SEPARATOR;
 
             $filename = $this->generateFileName($file, $path);
 

--- a/src/Http/Controllers/ContentTypes/MultipleImage.php
+++ b/src/Http/Controllers/ContentTypes/MultipleImage.php
@@ -48,7 +48,7 @@ class MultipleImage extends BaseType
             $resize_quality = intval($this->options->quality ?? 75);
 
             $filename = Str::random(20);
-            $path = $this->slug.DIRECTORY_SEPARATOR.date('FY').DIRECTORY_SEPARATOR;
+            $path = $this->slug.DIRECTORY_SEPARATOR;
             array_push($filesPath, $path.$filename.'.'.$file->getClientOriginalExtension());
             $filePath = $path.$filename.'.'.$file->getClientOriginalExtension();
 

--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -39,7 +39,7 @@ class VoyagerController extends Controller
             abort(403);
         }
 
-        $path = $slug.'/'.date('FY').'/';
+        $path = $slug.'/';
 
         $filename = basename($file->getClientOriginalName(), '.'.$file->getClientOriginalExtension());
         $filename_counter = 1;
@@ -90,7 +90,7 @@ class VoyagerController extends Controller
                 $normalizer = new \League\Flysystem\WhitespacePathNormalizer();
                 $path = dirname(__DIR__, 3).'/publishable/assets/'. $normalizer->normalizePath(urldecode($request->path));
             }
-            
+
         } catch (\LogicException $e) {
             abort(404);
         }


### PR DESCRIPTION
Urls of uploaded images and files is located in example.com/storage/posts/January2022/t95pEV39MWRf1SXI22VF.jpeg. This format is not usable if you upload image today but post date is from the past. In my opinion it would better to have change it in config file or the solution offered in this commit