### PR TITLE
Fix "Unable to init from given binary data." when upload media

### DIFF
--- a/src/Http/Controllers/VoyagerMediaController.php
+++ b/src/Http/Controllers/VoyagerMediaController.php
@@ -268,8 +268,8 @@ class VoyagerMediaController extends Controller
                 'image/svg+xml',
             ];
             if (in_array($request->file->getMimeType(), $imageMimeTypes)) {
-                $content = Storage::disk($this->filesystem)->get($file);
-                $image = Image::make($content);
+                $filePath = Str::finish($request->upload_path, '/') . $name . '.' . $extension;
+                $image = Image::make(Storage::disk($this->filesystem)->path($filePath));
 
                 if ($request->file->getClientOriginalExtension() == 'gif') {
                     copy($request->file->getRealPath(), $realPath.$file);


### PR DESCRIPTION
Storage::get($path) returns file contents as a string which may not be cast to valid binary data for Image::make() to be able to read.