### PR TITLE
Fix attribute/accessor not working in pivot table

### DIFF
--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -191,7 +191,7 @@
                                 )->pluck($options->table.'.'.$options->key);
                             }
                             $selected_keys = old($relationshipField, $selected_keys);
-                            $selected_values = app($options->model)->whereIn($options->key, $selected_keys)->pluck($options->label, $options->key);
+                            $selected_values = app($options->model)->whereIn($options->key, $selected_keys)->get()->pluck($options->label, $options->key);
                         @endphp
 
                         @if(!$row->required)

--- a/resources/views/formfields/relationship.blade.php
+++ b/resources/views/formfields/relationship.blade.php
@@ -123,9 +123,20 @@
                 @php
                     $relationshipData = (isset($data)) ? $data : $dataTypeContent;
 
-                    $selected_values = isset($relationshipData) ? $relationshipData->belongsToMany($options->model, $options->pivot_table, $options->foreign_pivot_key ?? null, $options->related_pivot_key ?? null, $options->parent_key ?? null, $options->key)->get()->map(function ($item, $key) use ($options) {
-            			return $item->{$options->label};
-            		})->all() : array();
+                    $selected_values = isset($relationshipData) ?
+                        $relationshipData->belongsToMany(
+                            $options->model,
+                            $options->pivot_table,
+                            $options->foreign_pivot_key ?? null,
+                            $options->related_pivot_key ?? null,
+                            $options->parent_key ?? null,
+                            $options->key
+                        )
+                        ->get()
+                        ->map(function ($item) use ($options) {
+                            return $item->{$options->label};
+                        })->all()
+                        : array();
                 @endphp
 
                 @if($view == 'browse')


### PR DESCRIPTION
- Fixed attribute/accessor not working when there's is a many-to-many relationship and you're trying to access the Edit page.

It would've displayed that the column could not be found instead of using the proper attribute.