### PR TITLE
Enable sort for relationship on full datas

### DIFF
--- a/src/Http/Controllers/VoyagerBaseController.php
+++ b/src/Http/Controllers/VoyagerBaseController.php
@@ -917,22 +917,35 @@ class VoyagerBaseController extends Controller
                 if ($search) {
                     // If we are using additional_attribute as label
                     if (in_array($options->label, $additional_attributes)) {
-                        $relationshipOptions = $model->get();
+                        $relationshipOptions = $model;
                         $relationshipOptions = $relationshipOptions->filter(function ($model) use ($search, $options) {
                             return stripos($model->{$options->label}, $search) !== false;
                         });
                         $total_count = $relationshipOptions->count();
-                        $relationshipOptions = $relationshipOptions->forPage($page, $on_page);
                     } else {
-                        $total_count = $model->where($options->label, 'LIKE', '%'.$search.'%')->count();
-                        $relationshipOptions = $model->take($on_page)->skip($skip)
-                            ->where($options->label, 'LIKE', '%'.$search.'%')
-                            ->get();
+                        $total_count = $model->where($options->label, 'LIKE', '%' . $search . '%')->count();
+                        $relationshipOptions = $model->where($options->label, 'LIKE', '%' . $search . '%');
                     }
                 } else {
                     $total_count = $model->count();
-                    $relationshipOptions = $model->take($on_page)->skip($skip)->get();
+                    $relationshipOptions = $model;
                 }
+
+                // Sort results
+                if (!empty($options->sort->field)) {
+                    $sort = SORT_REGULAR;
+                    if (!empty($options->sort->flag)) {
+                        $sort = str_replace('"', '', $options->sort->flag);
+                    }
+                    if (!empty($options->sort->direction)) {
+                        $relationshipOptions = $relationshipOptions->orderBy($options->sort->field, $options->sort->direction);
+                    }
+                }
+
+				$relationshipOptions = $relationshipOptions->get()
+				->skip($skip)
+				->take($on_page);
+
 
                 $results = [];
 


### PR DESCRIPTION
Enable sort for relationship on full data, not only page per page dataset.

For example, datas are 

eat
drink
apple
orange
diner
pen

Default Voyager sorting and displaying are, with 3 datas per page :

**first page**
apple
drink
eat

**second page**
diner
orange
pen


With my PR, sorting and displaying are

**first page**
apple
diner
drink

**second page**
eat
orange
pen