### PR TITLE
Enhance File Validation: Replace File::exists() with File::isFile()

### DIFF
--- a/src/Http/Controllers/VoyagerController.php
+++ b/src/Http/Controllers/VoyagerController.php
@@ -95,7 +95,7 @@ class VoyagerController extends Controller
             abort(404);
         }
 
-        if (File::exists($path)) {
+        if (File::isFile($path)) {
             $mime = '';
             if (Str::endsWith($path, '.js')) {
                 $mime = 'text/javascript';


### PR DESCRIPTION
This pull request addresses a potential security issue in file handling where `File::exists($path)` was used to check if a file exists before serving it. Since `File::exists()` is based on PHP's `file_exists()` function, it also returns true for directories, which could lead to unintended behavior or vulnerabilities when directories are accessed instead of files.